### PR TITLE
Patch & Improve home screen functionality

### DIFF
--- a/frontend/lib/data/repository.dart
+++ b/frontend/lib/data/repository.dart
@@ -17,6 +17,7 @@ class Repo extends ChangeNotifier {
   Map<String, Tag> _tags = {};
   final Map<String, Lecture> _lectures = {}; // 강의 메타는 필요 시 디렉토리별로 로드
   String _currentTagTheme = '파스텔'; // 현재 선택된 태그 색상 테마
+  final Map<String, bool> _subjectExpandedStates = {}; // 과목별 펼침/접힘 상태
 
   Future<void> init() async {
     _docs = Directory(
@@ -30,6 +31,7 @@ class Repo extends ChangeNotifier {
     await _loadSubjects();
     await _loadTags();
     await _loadTagTheme();
+    await loadSubjectExpandedStates();
 
     // 모든 강의 메타 로드
     final List<String> allLectureIds = _subjects.values
@@ -212,6 +214,36 @@ class Repo extends ChangeNotifier {
     _subjects[id] = s.copyWith(favorite: !s.favorite);
     await _saveSubjects();
     notifyListeners();
+  }
+
+  // 과목 펼침/접힘 상태 로드
+  Future<void> loadSubjectExpandedStates() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final List<String>? keys = prefs.getStringList('subject_expanded_states');
+    if (keys != null) {
+      for (final key in keys) {
+        final bool? value = prefs.getBool('subject_expanded_$key');
+        if (value != null) {
+          _subjectExpandedStates[key] = value;
+        }
+      }
+    }
+  }
+
+  // 과목 펼침/접힘 상태 저장
+  Future<void> saveSubjectExpandedState(String subjectId, bool expanded) async {
+    _subjectExpandedStates[subjectId] = expanded;
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('subject_expanded_$subjectId', expanded);
+    await prefs.setStringList(
+      'subject_expanded_states',
+      _subjectExpandedStates.keys.toList(),
+    );
+  }
+
+  // 과목 펼침/접힘 상태 가져오기 (기본값: true)
+  bool getSubjectExpandedState(String subjectId) {
+    return _subjectExpandedStates[subjectId] ?? true;
   }
 
   Future<void> _saveSubjects() async {

--- a/frontend/lib/features/home/home_screen.dart
+++ b/frontend/lib/features/home/home_screen.dart
@@ -244,47 +244,61 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
             ),
-          // 과목 패널 리스트
-          SliverList.builder(
-            itemCount: subjects.length,
-            itemBuilder: (context, i) {
-              final Subject s = subjects[i];
-              final List<Tag> subjectTags = s.tagIds
-                  .map(
-                    (tid) => tags.cast<Tag?>().firstWhere(
-                      (t) => t?.id == tid,
-                      orElse: () => null,
-                    ),
-                  )
-                  .whereType<Tag>()
-                  .toList();
-              // 태그 정렬: 숫자 > 한글 > 영어
-              subjectTags.sort((a, b) => _repo.compareTagNames(a.name, b.name));
-              final List<Lecture> lectures = _repo.lecturesBySubject(s.id);
-              return Padding(
-                padding: EdgeInsets.fromLTRB(16, i == 0 ? 6 : 12, 16, 0),
-                child: SubjectPanel(
-                  subject: s,
-                  tags: subjectTags,
-                  lectures: lectures,
-                  onToggleFavorite: () async {
-                    await _repo.toggleSubjectFavorite(s.id);
-                    // Repository가 notifyListeners()를 호출하므로 setState 불필요
-                  },
-                  onOpenLecture: (Lecture lec) {
-                    Navigator.pushNamed(
-                      context,
-                      Routes.player,
-                      arguments: {'lectureId': lec.id},
-                    );
-                  },
-                  onLectureUpdated: () {
-                    // Repository가 notifyListeners()를 호출하므로 setState 불필요
-                  },
+          // 과목 패널 리스트 또는 빈 상태 메시지
+          if (subjects.isEmpty)
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: EmptyStateMessage(
+                  message: favoritesOnly
+                      ? '즐겨찾기된 과목이 없습니다.'
+                      : selectedTagIds.isNotEmpty
+                          ? '필터와 일치하는 태그를 가진 과목이 없습니다.'
+                          : '',
                 ),
-              );
-            },
-          ),
+              ),
+            )
+          else
+            SliverList.builder(
+              itemCount: subjects.length,
+              itemBuilder: (context, i) {
+                final Subject s = subjects[i];
+                final List<Tag> subjectTags = s.tagIds
+                    .map(
+                      (tid) => tags.cast<Tag?>().firstWhere(
+                        (t) => t?.id == tid,
+                        orElse: () => null,
+                      ),
+                    )
+                    .whereType<Tag>()
+                    .toList();
+                // 태그 정렬: 숫자 > 한글 > 영어
+                subjectTags.sort((a, b) => _repo.compareTagNames(a.name, b.name));
+                final List<Lecture> lectures = _repo.lecturesBySubject(s.id);
+                return Padding(
+                  padding: EdgeInsets.fromLTRB(16, i == 0 ? 6 : 12, 16, 0),
+                  child: SubjectPanel(
+                    subject: s,
+                    tags: subjectTags,
+                    lectures: lectures,
+                    onToggleFavorite: () async {
+                      await _repo.toggleSubjectFavorite(s.id);
+                      // Repository가 notifyListeners()를 호출하므로 setState 불필요
+                    },
+                    onOpenLecture: (Lecture lec) {
+                      Navigator.pushNamed(
+                        context,
+                        Routes.player,
+                        arguments: {'lectureId': lec.id},
+                      );
+                    },
+                    onLectureUpdated: () {
+                      // Repository가 notifyListeners()를 호출하므로 setState 불필요
+                    },
+                  ),
+                );
+              },
+            ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
         ],
       ),

--- a/frontend/lib/features/home/home_screen.dart
+++ b/frontend/lib/features/home/home_screen.dart
@@ -57,6 +57,8 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         // Figma: 좌 햄버거, 중앙 타이틀, 우 검색
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
         leading: Builder(
           builder: (scaffoldContext) => IconButton(
             icon: const Icon(Icons.menu),

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -389,16 +389,11 @@ class _SubjectPanelState extends State<SubjectPanel>
     return List.generate(tags.length, (i) {
       final Tag t = tags[i];
       final Color tagColor = Color(t.color);
-      return ChoiceChip(
+      return Chip(
         label: Text('#${t.name}', style: const TextStyle(color: Colors.black)),
-        selected: false,
-        onSelected: (_) {}, // onSelected를 null이 아닌 빈 함수로
         backgroundColor: tagColor,
-        selectedColor: tagColor,
-        disabledColor: tagColor, // 비활성화 시에도 색상 유지
         elevation: 2,
         side: BorderSide.none,
-        showCheckmark: false,
       );
     });
   }

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -230,13 +230,16 @@ class SubjectPanel extends StatefulWidget {
 
 class _SubjectPanelState extends State<SubjectPanel>
     with SingleTickerProviderStateMixin {
-  bool expanded = true;
+  late bool expanded;
   late AnimationController _animationController;
   late Animation<double> _expandAnimation;
 
   @override
   void initState() {
     super.initState();
+    // Repository에서 저장된 상태 로드
+    expanded = Repo.instance.getSubjectExpandedState(widget.subject.id);
+
     final AccessibilityService accessibilityService = AccessibilityService();
     final Duration duration = accessibilityService.getAnimationDuration(
       const Duration(milliseconds: 300),
@@ -247,7 +250,7 @@ class _SubjectPanelState extends State<SubjectPanel>
       parent: _animationController,
       curve: accessibilityService.getAnimationCurve(Curves.easeInOut),
     );
-    _animationController.value = 1.0;
+    _animationController.value = expanded ? 1.0 : 0.0;
   }
 
   @override
@@ -263,6 +266,9 @@ class _SubjectPanelState extends State<SubjectPanel>
     setState(() {
       expanded = !expanded;
     });
+
+    // Repository에 상태 저장
+    Repo.instance.saveSubjectExpandedState(widget.subject.id, expanded);
 
     if (reduceMotion) {
       // 모션 줄이기가 활성화되면 즉시 전환

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -15,6 +15,35 @@ const _panelShadow = BoxShadow(
   offset: Offset(0, 3),
 );
 
+/// 빈 상태 메시지 위젯
+class EmptyStateMessage extends StatelessWidget {
+  const EmptyStateMessage({
+    super.key,
+    required this.message,
+  });
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    if (message.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Center(
+      child: Text(
+        message,
+        style: const TextStyle(
+          fontSize: 16,
+          color: Colors.black54,
+          fontWeight: FontWeight.w500,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+
 /// 필터 pill 버튼 위젯
 class FilterPill extends StatelessWidget {
   const FilterPill({

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -542,6 +542,16 @@ class _LectureCardState extends State<LectureCard> {
   }
 
   Widget _buildThumbnail() {
+    return AspectRatio(
+      aspectRatio: 16 / 9,
+      child: Container(
+        color: Colors.white,
+        child: _buildThumbnailContent(),
+      ),
+    );
+  }
+
+  Widget _buildThumbnailContent() {
     if (_isLoading) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -556,10 +566,21 @@ class _LectureCardState extends State<LectureCard> {
     }
 
     if (_cachedImage != null) {
+      // PDF의 비율 계산
+      final double pdfAspectRatio = _pdfPage!.width / _pdfPage!.height;
+      const double targetAspectRatio = 16 / 9;
+
+      // 4:3 비율인 경우 (또는 16:9보다 세로로 긴 경우) contain으로 중앙 정렬
+      // 16:9 비율인 경우 cover로 꽉 채우기
+      final BoxFit fit = pdfAspectRatio < targetAspectRatio
+          ? BoxFit.contain // 4:3 등 세로로 긴 경우 - 좌우 여백
+          : BoxFit.cover;   // 16:9 등 가로로 긴 경우 - 꽉 채우기
+
       return Image.memory(
         _cachedImage!.bytes,
-        fit: BoxFit.fitWidth,
+        fit: fit,
         width: double.infinity,
+        height: double.infinity,
       );
     }
 

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -283,9 +283,9 @@ class _SubjectPanelState extends State<SubjectPanel>
 
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: expanded ? Colors.white : Colors.transparent,
         borderRadius: BorderRadius.circular(_panelRadius),
-        boxShadow: const [_panelShadow],
+        boxShadow: expanded ? const [_panelShadow] : const [],
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -500,11 +500,11 @@ class _LectureCardState extends State<LectureCard> {
       onLongPress: () => _showLectureDetailDialog(context),
       child: Ink(
         decoration: BoxDecoration(
-          color: const Color(0xFFF6F7FA),
-          borderRadius: BorderRadius.circular(16),
+          color: Colors.transparent,
+          
           boxShadow: const [
             BoxShadow(
-              color: Color(0x0F000000),
+              color: Colors.transparent,
               blurRadius: 6,
               offset: Offset(0, 2),
             ),


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->
- Patched all bugs and necessary features mentioned at the end of Iteration 1

---

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Fixed lecture thumbnail ratio to 16:9, and in case of 4:3, it is center aligned with empty padding to either side
- Made sure the app remembers the last state of each subject toggle, and to maintain that state when reloaded
- Added text holder when filter tags match no subject / the 'favorites' folder is empty when the filter is activated
- Made the filter pill chips unclickable (as they do not have any function)
- Made sure the header doesn't change colors when scrolled (bug fix)
- Erased the mysterious.. rectangular shadows to the background that appears when the subject toggles are closed

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [ ] Added/updated tests
- [x] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
- The case when the lecture thumbnail is relatively wider than 16:9 needs to be discussed