### PR TITLE
Regenerate Hive TypeAdapters for hasCompletedTutorial field

### DIFF
--- a/frontend/lib/data/hive_models.g.dart
+++ b/frontend/lib/data/hive_models.g.dart
@@ -71,13 +71,14 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       ttsGender: fields[5] as String,
       ttsSpeed: fields[6] as String,
       tagColorTheme: fields[7] as String,
+      hasCompletedTutorial: fields[8] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, AppSettings obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.theme)
       ..writeByte(1)
@@ -93,7 +94,9 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       ..writeByte(6)
       ..write(obj.ttsSpeed)
       ..writeByte(7)
-      ..write(obj.tagColorTheme);
+      ..write(obj.tagColorTheme)
+      ..writeByte(8)
+      ..write(obj.hasCompletedTutorial);
   }
 
   @override


### PR DESCRIPTION
Fixes tutorial persistence issue where tutorial screen would appear on every app restart despite being completed.

## 📝 Description
- Regenerate hive_models.g.dart to include hasCompletedTutorial field
- This fixes tutorial screen appearing on every app restart
- The field was defined in hive_models.dart but missing from generated code
- Regenerated using: flutter pub run build_runner build --delete-conflicting-outputs
---

## 🔨 Changes Made
- Just regenerated hive_models.g.dart

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @del2090 
- @kwakmeensoo 

---

## 📌 Notes for Reviewers
Check whether the tutorial doesn't appear if it's not the first running after downloading
