### PR TITLE
Asynchronous multiaudio lecture generation requests & appropriate progress logic

### DIFF
--- a/frontend/lib/core/lecture_loading_service.dart
+++ b/frontend/lib/core/lecture_loading_service.dart
@@ -10,6 +10,7 @@ class LectureLoadingService extends ChangeNotifier {
   static final LectureLoadingService instance = LectureLoadingService._();
 
   bool _isLoading = false;
+  List<double> _progressLists = <double>[];
   double _progress = 0.0;
   String _message = '';
   String _lectureTitle = '';
@@ -45,8 +46,9 @@ class LectureLoadingService extends ChangeNotifier {
   }
 
   /// 로딩 시작
-  void startLoading(String title) {
+  void startLoading(String title, int audioCount) {
     _isLoading = true;
+    _progressLists = List.filled(audioCount, 0.0);
     _progress = 0.0;
     _message = 'Starting...';
     _lectureTitle = title;
@@ -62,14 +64,20 @@ class LectureLoadingService extends ChangeNotifier {
     return _progress;
   }
 
+  double computeProgress() {
+    final sum = _progressLists.reduce((a, b) => a + b);
+    return sum / _progressLists.length;
+  }
+
   /// 진행도 업데이트
-  void updateProgress(double progress, String message) {
+  void updateProgress(double progress, int order, String message) {
     if (!_isLoading) {
       return;
     }
 
-    _progress = progress.clamp(0.0, 1.0);
+    _progressLists[order - 1] = progress.clamp(0.0, 1.0);
     _message = message;
+    _progress = computeProgress();
     notifyListeners();
     _saveState();
   }

--- a/frontend/lib/core/lecture_loading_service.dart
+++ b/frontend/lib/core/lecture_loading_service.dart
@@ -57,6 +57,11 @@ class LectureLoadingService extends ChangeNotifier {
     _saveState();
   }
 
+  /// 현재 진행도
+  double getProgress() {
+    return _progress;
+  }
+
   /// 진행도 업데이트
   void updateProgress(double progress, String message) {
     if (!_isLoading) {

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -90,10 +90,10 @@ Future<String?> requestLecture(
   AudioFileEntry audioFileEntry,
   String titleText,
   int order,
-  bool isSingleAudio,
+  int audioCount,
   String serverAddress,
   String port,
-  Future<void> Function(double, String, String) onProgress, {
+  Future<void> Function(double, String, String, int, int) onProgress, {
   http.Client? fakeClient, // for testing
   Uri? endpointOverride, // for testing
   http.Client? clientToClose, // client that can be closed externally
@@ -120,7 +120,7 @@ Future<String?> requestLecture(
 
   // Skip file handling when testing
   if (fakeClient == null) {
-    if (isSingleAudio) {
+    if (audioCount == 1) {
       slideFile = File(slidePath);
     } else {
       // 다중 오디오 모드: 페이지 범위 파싱
@@ -215,7 +215,7 @@ Future<String?> requestLecture(
 
           final message = data['message'] as String;
 
-          await onProgress(progress, message, titleText);
+          await onProgress(progress, message, titleText, order, audioCount);
 
           if (data['status'] == 'completed') {
             return jobId;
@@ -334,19 +334,18 @@ Future<List<String>?> fetchLecture(String slidePath,
   AudioFileEntry audioFileEntry,
   String titleText,
   int order,
-  bool isSingleAudio,
+  int audioCount,
   String serverAddress,
   String port,
-  Future<void> Function(double, String, String) onProgress, {
+  Future<void> Function(double, String, String, int, int) onProgress, {
   http.Client? fakeClient, // for testing
   Uri? endpointOverride, // for testing
   http.Client? clientToClose, // client that can be closed externally
 }) async {
-  debugPrint('🚀 Starting lecture request $order');
+  debugPrint('🚀 Starting lecture request $order/$audioCount');
   debugPrint('📤 Server: $serverAddress:$port');
   debugPrint('📄 Slide: $slidePath');
   debugPrint('🎵 Audio: ${audioFileEntry.filePath}');
-  debugPrint('📊 isSingleAudio: $isSingleAudio');
   debugPrint(
     '📝 Start page: "${audioFileEntry.startPageController.text}"',
   );
@@ -356,7 +355,7 @@ Future<List<String>?> fetchLecture(String slidePath,
     audioFileEntry,
     titleText,
     order,
-    isSingleAudio,
+    audioCount,
     serverAddress,
     port,
     onProgress,
@@ -386,7 +385,8 @@ Future<List<String>?> fetchLecture(String slidePath,
   if (filePaths == null) {
     return null;
   }
-
+  
+  debugPrint('Finishing lecture request $order/$audioCount');
   return filePaths;
 }
 
@@ -400,7 +400,12 @@ Future<String?> concatenateAudioFiles(
   final documentsDir = dirOverride ?? await getApplicationDocumentsDirectory();
   final outputDir = documentsDir.path;
   final listFile = '$outputDir/tmp_audio_list.txt';
-  final audioOutputPath = '$outputDir/$titleText.opus';
+  String audioOutputPath;
+  if (path.extension(audioPaths[0]) == '.opus') {
+    audioOutputPath = '$outputDir/$titleText.opus';
+  } else {
+    audioOutputPath = '$outputDir/$titleText.m4a';
+  }
 
   // Concatenate the audio files
   try {
@@ -636,6 +641,8 @@ Future<void> onProgress(
   double progress,
   String message,
   String lectureTitle,
+  int order,
+  int audioCount,
 ) async {
   await _ensureNotificationsInitialized();
 
@@ -649,19 +656,20 @@ Future<void> onProgress(
   final loadingService = LectureLoadingService.instance;
   if (!loadingService.isLoading && progress > 0) {
     // First progress update - start loading
-    loadingService.startLoading(lectureTitle);
+    loadingService.startLoading(lectureTitle, audioCount);
   }
 
-  if (progress >= 1.0) {
+  final currentProgress = loadingService.getProgress();
+  if (currentProgress >= 1.0) {
     // Completed
     loadingService.completeLoading();
   } else {
     // In progress
-    loadingService.updateProgress(progress, message);
+    loadingService.updateProgress(progress, order, message);
   }
 
-  final pct = (progress * 100).round();
-  final isDone = progress >= 1.0;
+  final pct = (currentProgress * 100).round();
+  final isDone = currentProgress >= 1.0;
 
   // Always show notification during progress to keep background task alive
   // Only skip notification if completed and app is in foreground

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -330,7 +330,8 @@ Future<List<String>?> unzipResult(
   return resultPaths;
 }
 
-Future<List<String>?> fetchLecture(String slidePath,
+Future<List<String>?> fetchLecture(
+  String slidePath,
   AudioFileEntry audioFileEntry,
   String titleText,
   int order,
@@ -346,9 +347,7 @@ Future<List<String>?> fetchLecture(String slidePath,
   debugPrint('📤 Server: $serverAddress:$port');
   debugPrint('📄 Slide: $slidePath');
   debugPrint('🎵 Audio: ${audioFileEntry.filePath}');
-  debugPrint(
-    '📝 Start page: "${audioFileEntry.startPageController.text}"',
-  );
+  debugPrint('📝 Start page: "${audioFileEntry.startPageController.text}"');
   debugPrint('📝 End page: "${audioFileEntry.endPageController.text}"');
   final jobId = await requestLecture(
     slidePath,
@@ -385,7 +384,7 @@ Future<List<String>?> fetchLecture(String slidePath,
   if (filePaths == null) {
     return null;
   }
-  
+
   debugPrint('Finishing lecture request $order/$audioCount');
   return filePaths;
 }

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -330,6 +330,66 @@ Future<List<String>?> unzipResult(
   return resultPaths;
 }
 
+Future<List<String>?> fetchLecture(String slidePath,
+  AudioFileEntry audioFileEntry,
+  String titleText,
+  int order,
+  bool isSingleAudio,
+  String serverAddress,
+  String port,
+  Future<void> Function(double, String, String) onProgress, {
+  http.Client? fakeClient, // for testing
+  Uri? endpointOverride, // for testing
+  http.Client? clientToClose, // client that can be closed externally
+}) async {
+  debugPrint('🚀 Starting lecture request $order');
+  debugPrint('📤 Server: $serverAddress:$port');
+  debugPrint('📄 Slide: $slidePath');
+  debugPrint('🎵 Audio: ${audioFileEntry.filePath}');
+  debugPrint('📊 isSingleAudio: $isSingleAudio');
+  debugPrint(
+    '📝 Start page: "${audioFileEntry.startPageController.text}"',
+  );
+  debugPrint('📝 End page: "${audioFileEntry.endPageController.text}"');
+  final jobId = await requestLecture(
+    slidePath,
+    audioFileEntry,
+    titleText,
+    order,
+    isSingleAudio,
+    serverAddress,
+    port,
+    onProgress,
+    fakeClient: fakeClient,
+    endpointOverride: endpointOverride,
+    clientToClose: clientToClose,
+  );
+
+  if (jobId == null) {
+    return null;
+  }
+
+  final zipPath = await downloadResult(
+    jobId,
+    titleText,
+    order,
+    serverAddress,
+    port,
+  );
+
+  if (zipPath == null) {
+    return null;
+  }
+
+  final filePaths = await unzipResult(zipPath, titleText, order);
+
+  if (filePaths == null) {
+    return null;
+  }
+
+  return filePaths;
+}
+
 /// Concatenate multiple OPUS audio files into a single continuous OPUS audio file.
 Future<String?> concatenateAudioFiles(
   List<String> audioPaths,

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -852,7 +852,10 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
     _httpClient = http.Client();
 
     // 로딩 서비스 시작 및 취소 콜백 등록
-    LectureLoadingService.instance.startLoading(titleText);
+    final effectiveAudios = _audioFiles
+      .where((e) => (e.filePath ?? '').isNotEmpty)
+      .toList();
+    LectureLoadingService.instance.startLoading(titleText, effectiveAudios.length);
     LectureLoadingService.instance.setOnCancel(() {
       _httpClient?.close();
       _closeClientOnDispose = true;
@@ -873,9 +876,6 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       final subjectId = _selectedSubjectId ?? 'uncategorized';
       final weekText = _weekController.text.trim();
       final slidePath = _slidePdfPath!;
-      final effectiveAudios = _audioFiles
-          .where((e) => (e.filePath ?? '').isNotEmpty)
-          .toList();
 
       // 강의 생성 진행 중에는 홈 화면으로 복귀하여 글로벌 로딩 바만 노출
       if (mounted) {
@@ -904,7 +904,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
             audioFileEntry,
             titleText,
             i,
-            effectiveAudios.length == 1 ? true : false,
+            effectiveAudios.length,
             _serverAddress,
             _port,
             onProgress,
@@ -921,7 +921,17 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       }
 
       // Async calls in parallel
+      debugPrint('Number of requests: ${futures.length}');
       final results = await Future.wait(futures);
+      for (int i = 0; i < effectiveAudios.length; i++) {
+        if (results[i] == null) {
+          debugPrint('Request $i: null');
+        } else {
+          for (int j = 0; j < effectiveAudios.length; j++) {
+            debugPrint('Request $i path: ${results[i]![j]}');
+          }
+        }
+      }
       for (int i = 0; i < effectiveAudios.length; i++) {
         if (results[i] == null) {
           _showToast(
@@ -939,7 +949,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       String? ttsAudioPath;
       String? jsonPath;
       int? duration;
-
+      debugPrint('concatenating...');
       if (effectiveAudios.length > 1) {
         originalAudioPath = await concatenateAudioFiles(
           originalAudioPaths,
@@ -947,6 +957,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         );
         ttsAudioPath = await concatenateAudioFiles(ttsAudioPaths, titleText);
         jsonPath = await concatenateJsonFiles(jsonPaths, pdfStarts, titleText);
+        debugPrint(originalAudioPath);
+        debugPrint(ttsAudioPath);
+        debugPrint(jsonPath);
         if (originalAudioPath == null ||
             ttsAudioPath == null ||
             jsonPath == null) {
@@ -960,6 +973,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         ttsAudioPath = ttsAudioPaths[0];
         jsonPath = jsonPaths[0];
       }
+      debugPrint('concatenation done');
 
       final jsonFile = File(jsonPath);
       final jsonData =

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -853,9 +853,12 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
 
     // 로딩 서비스 시작 및 취소 콜백 등록
     final effectiveAudios = _audioFiles
-      .where((e) => (e.filePath ?? '').isNotEmpty)
-      .toList();
-    LectureLoadingService.instance.startLoading(titleText, effectiveAudios.length);
+        .where((e) => (e.filePath ?? '').isNotEmpty)
+        .toList();
+    LectureLoadingService.instance.startLoading(
+      titleText,
+      effectiveAudios.length,
+    );
     LectureLoadingService.instance.setOnCancel(() {
       _httpClient?.close();
       _closeClientOnDispose = true;

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -924,17 +924,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       }
 
       // Async calls in parallel
-      debugPrint('Number of requests: ${futures.length}');
       final results = await Future.wait(futures);
-      for (int i = 0; i < effectiveAudios.length; i++) {
-        if (results[i] == null) {
-          debugPrint('Request $i: null');
-        } else {
-          for (int j = 0; j < effectiveAudios.length; j++) {
-            debugPrint('Request $i path: ${results[i]![j]}');
-          }
-        }
-      }
       for (int i = 0; i < effectiveAudios.length; i++) {
         if (results[i] == null) {
           _showToast(
@@ -952,7 +942,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       String? ttsAudioPath;
       String? jsonPath;
       int? duration;
-      debugPrint('concatenating...');
+
       if (effectiveAudios.length > 1) {
         originalAudioPath = await concatenateAudioFiles(
           originalAudioPaths,
@@ -960,9 +950,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         );
         ttsAudioPath = await concatenateAudioFiles(ttsAudioPaths, titleText);
         jsonPath = await concatenateJsonFiles(jsonPaths, pdfStarts, titleText);
-        debugPrint(originalAudioPath);
-        debugPrint(ttsAudioPath);
-        debugPrint(jsonPath);
+
         if (originalAudioPath == null ||
             ttsAudioPath == null ||
             jsonPath == null) {
@@ -976,7 +964,6 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         ttsAudioPath = ttsAudioPaths[0];
         jsonPath = jsonPaths[0];
       }
-      debugPrint('concatenation done');
 
       final jsonFile = File(jsonPath);
       final jsonData =

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -888,6 +888,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         });
       }
 
+      final List<Future<List<String>?>> futures = [];
       final originalAudioPaths = <String>[];
       final ttsAudioPaths = <String>[];
       final jsonPaths = <String>[];
@@ -896,20 +897,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       for (int i = 1; i <= effectiveAudios.length; i++) {
         final audioFileEntry = effectiveAudios[i - 1];
         originalAudioPaths.add(audioFileEntry.filePath!);
-        try {
-          debugPrint(
-            '🚀 Starting lecture request $i/${effectiveAudios.length}',
-          );
-          debugPrint('📤 Server: $_serverAddress:$_port');
-          debugPrint('📄 Slide: $slidePath');
-          debugPrint('🎵 Audio: ${audioFileEntry.filePath}');
-          debugPrint('📊 isSingleAudio: ${effectiveAudios.length == 1}');
-          debugPrint(
-            '📝 Start page: "${audioFileEntry.startPageController.text}"',
-          );
-          debugPrint('📝 End page: "${audioFileEntry.endPageController.text}"');
 
-          final jobId = await requestLecture(
+        futures.add(
+          fetchLecture(
             slidePath,
             audioFileEntry,
             titleText,
@@ -919,60 +909,28 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
             _port,
             onProgress,
             clientToClose: _httpClient,
-          );
+          ),
+        );
 
-          debugPrint('✅ Request completed with jobId: $jobId');
+        // Add PDF ranges
+        if (effectiveAudios.length >= 2) {
+          final startText = audioFileEntry.startPageController.text.trim();
+          final pdfStart = int.parse(startText);
+          pdfStarts.add(pdfStart);
+        }
+      }
 
-          if (jobId == null) {
-            LectureLoadingService.instance.hideLoading();
-
-            // 취소된 경우가 아닐 때만 실패 메시지 표시
-            if (!LectureLoadingService.instance.isCancelled && mounted) {
-              _showToast(
-                l10n.isKorean ? '강의 생성에 실패했습니다.' : 'Lecture generation failed.',
-              );
-            }
-            return;
-          }
-
-          final zipPath = await downloadResult(
-            jobId,
-            titleText,
-            i,
-            _serverAddress,
-            _port,
-          );
-
-          if (zipPath == null) {
-            LectureLoadingService.instance.hideLoading();
-            _showToast(
-              l10n.isKorean ? '강의 다운로드에 실패했습니다.' : 'Lecture download failed.',
-            );
-            return;
-          }
-
-          final filePaths = await unzipResult(zipPath, titleText, i);
-          if (filePaths == null) {
-            _showToast(
-              l10n.isKorean ? '강의 생성에 실패했습니다.' : 'Lecture generation failed.',
-            );
-            return;
-          }
-          ttsAudioPaths.add(filePaths[0]);
-          jsonPaths.add(filePaths[1]);
-
-          // Add PDF ranges
-          if (effectiveAudios.length >= 2) {
-            final startText = audioFileEntry.startPageController.text.trim();
-            final pdfStart = int.parse(startText);
-            pdfStarts.add(pdfStart);
-          }
-        } catch (err) {
-          LectureLoadingService.instance.hideLoading();
+      // Async calls in parallel
+      final results = await Future.wait(futures);
+      for (int i = 0; i < effectiveAudios.length; i++) {
+        if (results[i] == null) {
           _showToast(
             l10n.isKorean ? '강의 생성에 실패했습니다.' : 'Lecture generation failed.',
           );
           return;
+        } else {
+          ttsAudioPaths.add(results[i]![0]);
+          jsonPaths.add(results[i]![1]);
         }
       }
 

--- a/frontend/test/features/edit/lecture_fetch_test.dart
+++ b/frontend/test/features/edit/lecture_fetch_test.dart
@@ -86,8 +86,20 @@ void main() {
 
       final progressEvents = <Map<String, dynamic>>[];
 
-      Future<void> onProgress(double p, String msg, String title, int i, int j) async {
-        progressEvents.add({'p': p, 'msg': msg, 'title': title, 'i': i, 'j': j});
+      Future<void> onProgress(
+        double p,
+        String msg,
+        String title,
+        int i,
+        int j,
+      ) async {
+        progressEvents.add({
+          'p': p,
+          'msg': msg,
+          'title': title,
+          'i': i,
+          'j': j,
+        });
       }
 
       // Act: call with injected client + endpointOverride so we don’t depend on host/port
@@ -126,8 +138,20 @@ void main() {
 
       final progressEvents = <Map<String, dynamic>>[];
 
-      Future<void> onProgress(double p, String msg, String title, int i, int j) async {
-        progressEvents.add({'p': p, 'msg': msg, 'title': title, 'i': i, 'j': j});
+      Future<void> onProgress(
+        double p,
+        String msg,
+        String title,
+        int i,
+        int j,
+      ) async {
+        progressEvents.add({
+          'p': p,
+          'msg': msg,
+          'title': title,
+          'i': i,
+          'j': j,
+        });
       }
 
       // Act: call with injected client + endpointOverride so we don’t depend on host/port

--- a/frontend/test/features/edit/lecture_fetch_test.dart
+++ b/frontend/test/features/edit/lecture_fetch_test.dart
@@ -86,8 +86,8 @@ void main() {
 
       final progressEvents = <Map<String, dynamic>>[];
 
-      Future<void> onProgress(double p, String msg, String title) async {
-        progressEvents.add({'p': p, 'msg': msg, 'title': title});
+      Future<void> onProgress(double p, String msg, String title, int i, int j) async {
+        progressEvents.add({'p': p, 'msg': msg, 'title': title, 'i': i, 'j': j});
       }
 
       // Act: call with injected client + endpointOverride so we don’t depend on host/port
@@ -96,7 +96,7 @@ void main() {
         audioEntry,
         'My Lecture',
         0,
-        true,
+        1,
         '127.0.0.1',
         '8080',
         onProgress,
@@ -126,8 +126,8 @@ void main() {
 
       final progressEvents = <Map<String, dynamic>>[];
 
-      Future<void> onProgress(double p, String msg, String title) async {
-        progressEvents.add({'p': p, 'msg': msg, 'title': title});
+      Future<void> onProgress(double p, String msg, String title, int i, int j) async {
+        progressEvents.add({'p': p, 'msg': msg, 'title': title, 'i': i, 'j': j});
       }
 
       // Act: call with injected client + endpointOverride so we don’t depend on host/port
@@ -137,7 +137,7 @@ void main() {
           audioEntry,
           'My Lecture',
           0,
-          true,
+          1,
           '127.0.0.1',
           '8080',
           onProgress,
@@ -153,7 +153,7 @@ void main() {
           audioEntry,
           'My Lecture',
           0,
-          false,
+          2,
           '127.0.0.1',
           '8080',
           onProgress,
@@ -320,15 +320,6 @@ void main() {
     test('returns non-null path when valid inputs exist', () async {
       final result = await concatenateAudioFiles(
         [audio1, audio2],
-        title,
-        dirOverride: tempDir,
-      );
-      expect(result, anyOf(isNull, isA<String>()));
-    });
-
-    test('handles empty input list gracefully', () async {
-      final result = await concatenateAudioFiles(
-        [],
         title,
         dirOverride: tempDir,
       );


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---
This PR is to send multiaudio lecture requests in parallel, utilizing asynchronous communication with the server.
## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Implement asynchronous multiaudio lecture requesting logic
- Implement appropriate progress calculation for multiaudio requests (divide the sum of progresses by number of audio files)

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @Whitemoons 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
