### PR TITLE
Refine tags_edit_screen.dart UI design, add feature modifying subjects' locations, and remove feature changing tts speed

### DIFF
--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -100,6 +100,7 @@ class AppLocalizations {
   String get colorTheme => isKorean ? '색상 테마' : 'Color Theme';
   String get tagName => isKorean ? '이름' : 'Name';
   String get apply => isKorean ? '적용' : 'Apply';
+  String get nameApply => isKorean ? '이름 적용' : 'Apply Name';
   String get newTag => isKorean ? '새 태그' : 'New Tag';
   String get deleteTag => isKorean ? '태그 삭제' : 'Delete Tag';
   String get maxTagsReached =>

--- a/frontend/lib/data/hive_manager.dart
+++ b/frontend/lib/data/hive_manager.dart
@@ -207,6 +207,7 @@ class HiveManager extends ChangeNotifier {
   Map<String, HiveTag> get tags => _appData?.tags ?? {};
   UiState get uiState => _appData?.uiState ?? UiState();
   Map<String, HiveLecture> get lectures => _appData?.lectures ?? {};
+  List<String> get subjectOrder => _appData?.subjectOrder ?? [];
 
   // ========== 설정 관련 ==========
 
@@ -258,8 +259,26 @@ class HiveManager extends ChangeNotifier {
     bool favoritesOnly = false,
     List<String> filterTagIds = const [],
   }) {
-    List<HiveSubject> list = subjects.values.toList()
-      ..sort((a, b) => a.title.compareTo(b.title));
+    List<HiveSubject> list;
+
+    // 저장된 순서가 있으면 그 순서를 사용, 없으면 알파벳 순
+    if (subjectOrder.isNotEmpty) {
+      // subjectOrder에 있는 과목들을 순서대로 추가
+      list = subjectOrder
+          .map((id) => subjects[id])
+          .whereType<HiveSubject>()
+          .toList();
+
+      // subjectOrder에 없는 과목들을 알파벳 순으로 추가
+      final orderedIds = subjectOrder.toSet();
+      final remainingSubjects =
+          subjects.values.where((s) => !orderedIds.contains(s.id)).toList()
+            ..sort((a, b) => a.title.compareTo(b.title));
+      list.addAll(remainingSubjects);
+    } else {
+      list = subjects.values.toList()
+        ..sort((a, b) => a.title.compareTo(b.title));
+    }
 
     if (favoritesOnly) {
       list = list.where((s) => s.favorite).toList();
@@ -312,11 +331,18 @@ class HiveManager extends ChangeNotifier {
       tagIds: tagIds,
       lectureIds: [],
     );
+
+    // 새 과목을 순서 목록의 맨 앞에 추가
+    if (!subjectOrder.contains(newId)) {
+      subjectOrder.insert(0, newId);
+    }
+
     await _save();
   }
 
   Future<void> deleteSubject(String id) async {
     subjects.remove(id);
+    subjectOrder.remove(id); // 순서 목록에서도 제거
     await _save();
   }
 
@@ -331,6 +357,13 @@ class HiveManager extends ChangeNotifier {
 
   Future<void> updateSubjectTags(String id, List<String> tagIds) async {
     await updateSubject(id, tagIds: tagIds);
+  }
+
+  /// 과목 순서 업데이트
+  Future<void> updateSubjectOrder(List<String> newOrder) async {
+    _appData?.subjectOrder.clear();
+    _appData?.subjectOrder.addAll(newOrder);
+    await _save();
   }
 
   // ========== 태그 관련 ==========

--- a/frontend/lib/data/hive_manager.dart
+++ b/frontend/lib/data/hive_manager.dart
@@ -238,12 +238,9 @@ class HiveManager extends ChangeNotifier {
     await _save();
   }
 
-  Future<void> updateTts({String? gender, String? speed}) async {
+  Future<void> updateTts({String? gender}) async {
     if (gender != null) {
       settings.ttsGender = gender;
-    }
-    if (speed != null) {
-      settings.ttsSpeed = speed;
     }
     await _save();
   }

--- a/frontend/lib/data/hive_models.dart
+++ b/frontend/lib/data/hive_models.dart
@@ -54,7 +54,6 @@ class AppSettings {
     this.accessibilityReduceMotion = false,
     this.accessibilityEmphasizeCaptions = true,
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.tagColorTheme = '봄',
     this.hasCompletedTutorial = false,
   });
@@ -78,12 +77,9 @@ class AppSettings {
   String ttsGender; // '남성', '여성'
 
   @HiveField(6)
-  String ttsSpeed; // '빠르게', '보통', '느리게'
-
-  @HiveField(7)
   String tagColorTheme; // '봄', '여름', '가을', '겨울', '솜사탕', '비비드', '바다'
 
-  @HiveField(8)
+  @HiveField(7)
   bool hasCompletedTutorial;
 }
 

--- a/frontend/lib/data/hive_models.dart
+++ b/frontend/lib/data/hive_models.dart
@@ -15,12 +15,14 @@ class AppData extends HiveObject {
     Map<String, HiveTag>? tags,
     Map<String, HiveLecture>? lectures,
     UiState? uiState,
+    List<String>? subjectOrder,
   }) {
     this.settings = settings ?? AppSettings();
     this.subjects = subjects ?? {};
     this.tags = tags ?? {};
     this.lectures = lectures ?? {};
     this.uiState = uiState ?? UiState();
+    this.subjectOrder = subjectOrder ?? [];
   }
 
   @HiveField(0)
@@ -37,6 +39,9 @@ class AppData extends HiveObject {
 
   @HiveField(4)
   late Map<String, HiveLecture> lectures;
+
+  @HiveField(5)
+  late List<String> subjectOrder;
 }
 
 /// 앱 설정 (테마, 언어, 접근성, TTS 등)

--- a/frontend/lib/data/hive_models.g.dart
+++ b/frontend/lib/data/hive_models.g.dart
@@ -72,16 +72,15 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       accessibilityReduceMotion: fields[3] as bool,
       accessibilityEmphasizeCaptions: fields[4] as bool,
       ttsGender: fields[5] as String,
-      ttsSpeed: fields[6] as String,
-      tagColorTheme: fields[7] as String,
-      hasCompletedTutorial: fields[8] as bool,
+      tagColorTheme: fields[6] as String,
+      hasCompletedTutorial: fields[7] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, AppSettings obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.theme)
       ..writeByte(1)
@@ -95,10 +94,8 @@ class AppSettingsAdapter extends TypeAdapter<AppSettings> {
       ..writeByte(5)
       ..write(obj.ttsGender)
       ..writeByte(6)
-      ..write(obj.ttsSpeed)
-      ..writeByte(7)
       ..write(obj.tagColorTheme)
-      ..writeByte(8)
+      ..writeByte(7)
       ..write(obj.hasCompletedTutorial);
   }
 

--- a/frontend/lib/data/hive_models.g.dart
+++ b/frontend/lib/data/hive_models.g.dart
@@ -22,13 +22,14 @@ class AppDataAdapter extends TypeAdapter<AppData> {
       tags: (fields[2] as Map?)?.cast<String, HiveTag>(),
       lectures: (fields[4] as Map?)?.cast<String, HiveLecture>(),
       uiState: fields[3] as UiState?,
+      subjectOrder: (fields[5] as List?)?.cast<String>(),
     );
   }
 
   @override
   void write(BinaryWriter writer, AppData obj) {
     writer
-      ..writeByte(5)
+      ..writeByte(6)
       ..writeByte(0)
       ..write(obj.settings)
       ..writeByte(1)
@@ -38,7 +39,9 @@ class AppDataAdapter extends TypeAdapter<AppData> {
       ..writeByte(3)
       ..write(obj.uiState)
       ..writeByte(4)
-      ..write(obj.lectures);
+      ..write(obj.lectures)
+      ..writeByte(5)
+      ..write(obj.subjectOrder);
   }
 
   @override

--- a/frontend/lib/features/settings/tts_screen.dart
+++ b/frontend/lib/features/settings/tts_screen.dart
@@ -22,23 +22,6 @@ class TtsScreen extends StatefulWidget {
 
   @override
   State<TtsScreen> createState() => _TtsScreenState();
-
-  /// TTS 음성 속도를 재생 비율로 변환
-  ///
-  /// - 빠르게: 1.5 (주어진 시간 대비 꽤 빠르게 읽음)
-  /// - 보통: 1.0 (조금 빠르게 읽음)
-  /// - 느리게: 0.7 (주어진 시간을 꽉 채워 읽음)
-  static double speedToRate(String speed) {
-    switch (speed) {
-      case '빠르게':
-        return 1.5;
-      case '느리게':
-        return 0.7;
-      case '보통':
-      default:
-        return 1.0;
-    }
-  }
 }
 
 class _TtsScreenState extends State<TtsScreen> {
@@ -46,8 +29,6 @@ class _TtsScreenState extends State<TtsScreen> {
 
   // TTS 설정 상태
   String _gender = '남성'; // 음성 성별
-  String _speed = '보통'; // TTS 음성 속도 (빠르게/보통/느리게)
-  bool _isLoading = true; // 로딩 상태
 
   @override
   void initState() {
@@ -61,8 +42,6 @@ class _TtsScreenState extends State<TtsScreen> {
     if (mounted) {
       setState(() {
         _gender = _hiveManager.settings.ttsGender;
-        _speed = _hiveManager.settings.ttsSpeed;
-        _isLoading = false;
       });
     }
   }
@@ -71,13 +50,6 @@ class _TtsScreenState extends State<TtsScreen> {
   Future<void> _saveGender(String value) async {
     await _hiveManager.updateTts(gender: value);
     setState(() => _gender = value);
-    _playPreviewTTS();
-  }
-
-  /// TTS 음성 속도 저장 및 예시 음성 재생
-  Future<void> _saveSpeed(String value) async {
-    await _hiveManager.updateTts(speed: value);
-    setState(() => _speed = value);
     _playPreviewTTS();
   }
 
@@ -98,10 +70,6 @@ class _TtsScreenState extends State<TtsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (_isLoading) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
-    }
-
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final isKorean = AppLocalizations.of(context).isKorean;
 
@@ -125,10 +93,6 @@ class _TtsScreenState extends State<TtsScreen> {
             _buildSectionTitle(isKorean ? 'TTS 음성 성별' : 'TTS Voice Gender'),
             const SizedBox(height: 12),
             _buildGenderButtons(isKorean),
-            const SizedBox(height: 32),
-            _buildSectionTitle(isKorean ? 'TTS 음성 속도' : 'TTS Voice Speed'),
-            const SizedBox(height: 12),
-            _buildSpeedRadioButtons(isKorean),
           ],
         ),
       ),
@@ -152,18 +116,6 @@ class _TtsScreenState extends State<TtsScreen> {
         Expanded(
           child: _genderButton(isKorean ? '여성' : 'Female', _gender == '여성'),
         ),
-      ],
-    );
-  }
-
-  Widget _buildSpeedRadioButtons(bool isKorean) {
-    return Column(
-      children: [
-        _speedRadioButton(isKorean ? '빠르게' : 'Fast', '빠르게'),
-        const SizedBox(height: 8),
-        _speedRadioButton(isKorean ? '보통' : 'Normal', '보통'),
-        const SizedBox(height: 8),
-        _speedRadioButton(isKorean ? '느리게' : 'Slow', '느리게'),
       ],
     );
   }
@@ -197,62 +149,6 @@ class _TtsScreenState extends State<TtsScreen> {
           ),
         ),
       ),
-    );
-  }
-
-  Widget _speedRadioButton(String label, String value) {
-    final isSelected = _speed == value;
-
-    return GestureDetector(
-      onTap: () => _saveSpeed(value),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: const Color(0xFFE0E0E0)),
-        ),
-        child: Row(
-          children: [
-            _buildRadioIcon(isSelected),
-            const SizedBox(width: 12),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                color: isSelected ? Colors.black : const Color(0xFF666666),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildRadioIcon(bool isSelected) {
-    return Container(
-      width: 20,
-      height: 20,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        border: Border.all(
-          color: isSelected ? const Color(0xFF424242) : const Color(0xFFBDBDBD),
-          width: 2,
-        ),
-      ),
-      child: isSelected
-          ? Center(
-              child: Container(
-                width: 10,
-                height: 10,
-                decoration: const BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: Color(0xFF424242),
-                ),
-              ),
-            )
-          : null,
     );
   }
 }

--- a/frontend/lib/features/subjects/subjects_edit_screen.dart
+++ b/frontend/lib/features/subjects/subjects_edit_screen.dart
@@ -40,8 +40,17 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
   final Map<String, List<String>> _workingTagIds = {};
   final Map<String, String> _workingTitles = {};
 
+  // 작업 중인 과목 순서 (드래그앤드롭으로 변경 가능)
+  List<String> _workingSubjectOrder = [];
+
   // 삭제된 과목 ID 목록
   final Set<String> _deletedSubjectIds = {};
+
+  // 스크롤 컨트롤러 (자동 스크롤을 위해)
+  final ScrollController _scrollController = ScrollController();
+
+  // 저장 중 플래그 (저장 중에는 Hive 변경 리스너를 무시)
+  bool _isSaving = false;
 
   @override
   void initState() {
@@ -52,27 +61,38 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
     hive.addListener(_onDataChanged);
   }
 
-  /// 초기화: 편집용 작업 복사본 생성
-  ///
-  /// 원본 데이터를 보존하면서 사용자가 편집할 수 있도록
-  /// 모든 과목의 강의 ID와 태그 ID를 복사합니다.
-  void _initializeWorkingData() {
-    for (final subject in hive.getSubjects()) {
-      _workingLectureIds[subject.id] = List.from(subject.lectureIds);
-      _workingTagIds[subject.id] = List.from(subject.tagIds);
-      _workingTitles[subject.id] = subject.title;
-    }
-  }
-
   @override
   void dispose() {
+    _scrollController.dispose();
     // 리스너 해제
     hive.removeListener(_onDataChanged);
     super.dispose();
   }
 
+  /// 초기화: 편집용 작업 복사본 생성
+  ///
+  /// 원본 데이터를 보존하면서 사용자가 편집할 수 있도록
+  /// 모든 과목의 강의 ID와 태그 ID를 복사합니다.
+  void _initializeWorkingData() {
+    final subjects = hive.getSubjects();
+
+    for (final subject in subjects) {
+      _workingLectureIds[subject.id] = List.from(subject.lectureIds);
+      _workingTagIds[subject.id] = List.from(subject.tagIds);
+      _workingTitles[subject.id] = subject.title;
+    }
+
+    // 과목 순서 초기화 (현재 getSubjects()가 반환하는 순서)
+    _workingSubjectOrder = subjects.map((s) => s.id).toList();
+  }
+
   /// Hive 데이터 변경 시 호출되어 화면을 다시 빌드
   void _onDataChanged() {
+    // 저장 중일 때는 리스너를 무시 (저장 과정에서 발생하는 변경사항은 무시)
+    if (_isSaving) {
+      return;
+    }
+
     if (mounted) {
       // 데이터가 변경되었으므로, 작업용 데이터도 다시 초기화
       setState(() {
@@ -83,11 +103,17 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // 삭제되지 않은 과목 목록만 표시
-    final subjects = hive
-        .getSubjects()
-        .map((s) => s.toSubject())
-        .where((s) => !_deletedSubjectIds.contains(s.id))
+    // 삭제되지 않은 과목 목록을 _workingSubjectOrder 순서대로 정렬
+    final subjectMap = {
+      for (var s in hive.getSubjects().map((s) => s.toSubject())) s.id: s,
+    };
+
+    final subjects = _workingSubjectOrder
+        .where(
+          (id) =>
+              !_deletedSubjectIds.contains(id) && subjectMap.containsKey(id),
+        )
+        .map((id) => subjectMap[id]!)
         .toList();
 
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -106,23 +132,60 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
       ),
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
 
-      // 과목 목록 (스크롤 가능)
-      body: ListView.separated(
-        padding: const EdgeInsets.fromLTRB(16, 12, 16, 100),
+      // 과목 목록 (드래그앤드롭 가능)
+      body: ReorderableListView.builder(
+        buildDefaultDragHandles: false,
+        scrollController: _scrollController,
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
         itemCount: subjects.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        onReorder: (oldIndex, newIndex) {
+          setState(() {
+            // 드래그앤드롭 인덱스 조정
+            if (newIndex > oldIndex) {
+              newIndex -= 1;
+            }
+
+            // subjects 리스트 기반으로 재정렬
+            final reorderedSubjects = List<Subject>.from(subjects);
+            final movedSubject = reorderedSubjects.removeAt(oldIndex);
+            reorderedSubjects.insert(newIndex, movedSubject);
+
+            // _workingSubjectOrder를 새 순서로 업데이트
+            _workingSubjectOrder = reorderedSubjects.map((s) => s.id).toList();
+          });
+        },
+        proxyDecorator: (child, index, animation) {
+          return AnimatedBuilder(
+            animation: animation,
+            builder: (context, child) {
+              return Material(
+                elevation: 8,
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(_editPanelRadius),
+                child: child,
+              );
+            },
+            child: child,
+          );
+        },
         itemBuilder: (_, index) {
           final subject = subjects[index];
-          return _buildSubjectPanel(subject);
+          return Padding(
+            key: ValueKey(subject.id),
+            padding: const EdgeInsets.only(bottom: 12),
+            child: _buildSubjectPanel(subject, index),
+          );
         },
       ),
 
       // 하단 고정 버튼 ([수정 완료] [취소])
-      bottomNavigationBar: _BottomBar(
-        primaryLabel: AppLocalizations.of(context).editComplete,
-        secondaryLabel: AppLocalizations.of(context).cancel,
-        onPrimary: _saveChanges,
-        onSecondary: () => Navigator.pop(context),
+      bottomNavigationBar: SafeArea(
+        child: _BottomBar(
+          primaryLabel: AppLocalizations.of(context).editComplete,
+          secondaryLabel: AppLocalizations.of(context).cancel,
+          onPrimary: _saveChanges,
+          onSecondary: () => Navigator.pop(context),
+        ),
       ),
     );
   }
@@ -130,7 +193,7 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
   /// 과목 패널 빌더
   ///
   /// 각 과목의 강의 목록을 표시하고 드래그 앤 드롭으로 순서를 재정렬할 수 있습니다.
-  Widget _buildSubjectPanel(Subject subject) {
+  Widget _buildSubjectPanel(Subject subject, int index) {
     final lectureIds = _workingLectureIds[subject.id]!;
     final isExpanded = hive.getSubjectExpandedState(subject.id);
 
@@ -154,7 +217,7 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
     }).toList();
 
     return _SubjectEditPanel(
-      key: ValueKey(subject.id),
+      index: index,
       subject: subject,
       displayTitle: _workingTitles[subject.id],
       isInitiallyExpanded: isExpanded,
@@ -187,31 +250,42 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
   /// 모든 편집 내용(삭제, 순서 변경, 태그 변경, 제목 변경)을 저장하고
   /// 홈 화면을 새로고침한 후 이전 화면으로 돌아갑니다.
   Future<void> _saveChanges() async {
-    // 1. 삭제된 과목 처리
-    for (final subjectId in _deletedSubjectIds) {
-      await hive.deleteSubject(subjectId);
-    }
+    // 저장 시작 - 리스너 무시 플래그 설정
+    _isSaving = true;
 
-    // 2. 과목 제목, 강의 순서 및 태그 업데이트
-    for (final subject in hive.getSubjects()) {
-      if (!_deletedSubjectIds.contains(subject.id)) {
-        // 제목 업데이트
-        final newTitle = _workingTitles[subject.id];
-        if (newTitle != null && newTitle != subject.title) {
-          await hive.updateSubjectTitle(subject.id, newTitle);
-        }
-
-        await hive.updateSubjectLectures(
-          subject.id,
-          _workingLectureIds[subject.id]!,
-        );
-        await hive.updateSubjectTags(subject.id, _workingTagIds[subject.id]!);
+    try {
+      // 1. 삭제된 과목 처리
+      for (final subjectId in _deletedSubjectIds) {
+        await hive.deleteSubject(subjectId);
       }
-    }
 
-    // 3. 이전 화면으로 돌아가기
-    if (mounted) {
-      Navigator.pop(context);
+      // 2. 과목 제목, 강의 순서 및 태그 업데이트
+      for (final subject in hive.getSubjects()) {
+        if (!_deletedSubjectIds.contains(subject.id)) {
+          // 제목 업데이트
+          final newTitle = _workingTitles[subject.id];
+          if (newTitle != null && newTitle != subject.title) {
+            await hive.updateSubjectTitle(subject.id, newTitle);
+          }
+
+          await hive.updateSubjectLectures(
+            subject.id,
+            _workingLectureIds[subject.id]!,
+          );
+          await hive.updateSubjectTags(subject.id, _workingTagIds[subject.id]!);
+        }
+      }
+
+      // 3. 과목 순서 저장
+      await hive.updateSubjectOrder(_workingSubjectOrder);
+
+      // 4. 이전 화면으로 돌아가기
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } finally {
+      // 저장 완료 - 플래그 해제
+      _isSaving = false;
     }
   }
 
@@ -395,6 +469,11 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
         _workingLectureIds[newSubject.id] = [];
         _workingTagIds[newSubject.id] = List.from(selectedTagIds);
         _workingTitles[newSubject.id] = newSubject.title;
+
+        // 새 과목을 _workingSubjectOrder의 맨 앞에 추가
+        if (!_workingSubjectOrder.contains(newSubject.id)) {
+          _workingSubjectOrder.insert(0, newSubject.id);
+        }
       });
     }
   }
@@ -600,7 +679,7 @@ class _SubjectEditDialogState extends State<_SubjectEditDialog> {
                 width: MediaQuery.of(context).size.width * 0.4,
                 child: FilledButton.icon(
                   style: FilledButton.styleFrom(
-                    backgroundColor: Colors.red,
+                    backgroundColor: const Color.fromARGB(255, 231, 76, 60),
                     foregroundColor: Colors.white,
                   ),
                   onPressed: () {
@@ -652,7 +731,7 @@ class _SubjectEditDialogState extends State<_SubjectEditDialog> {
 /// - 롱프레스로 과목 편집 다이얼로그 열기
 class _SubjectEditPanel extends StatefulWidget {
   const _SubjectEditPanel({
-    super.key,
+    required this.index,
     required this.subject,
     this.displayTitle,
     required this.isInitiallyExpanded,
@@ -662,6 +741,7 @@ class _SubjectEditPanel extends StatefulWidget {
     required this.onExpansionChanged,
   });
 
+  final int index;
   final Subject subject;
   final String? displayTitle;
   final bool isInitiallyExpanded;
@@ -701,7 +781,7 @@ class _SubjectEditPanelState extends State<_SubjectEditPanel>
       curve: reduceMotion ? Curves.linear : Curves.easeInOut,
     );
     _colorAnimation = ColorTween(
-      begin: Colors.transparent,
+      begin: Colors.white,
       end: Colors.white,
     ).animate(_animationController);
 
@@ -739,10 +819,75 @@ class _SubjectEditPanelState extends State<_SubjectEditPanel>
     }
   }
 
+  /// 드래그 가능한 헤더 빌드 (드래그 핸들 포함)
+  Widget _buildDraggableHeader() {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color headerColor = isDark
+        ? const Color(0xFF2D2D2D) // 다크모드: 어두운 회색
+        : const Color(0xFF1D1D1D); // 라이트모드: 검은색
+    final Color textColor = Colors.white;
+    final Color iconColor = Colors.white;
+
+    final BorderRadius resolvedRadius = expanded
+        ? BorderRadius.only(
+            topLeft: Radius.circular(_editPanelRadius),
+            topRight: Radius.circular(_editPanelRadius),
+          )
+        : BorderRadius.circular(_editPanelRadius);
+
+    return GestureDetector(
+      onLongPress: widget.onLongPress,
+      child: Container(
+        decoration: BoxDecoration(
+          color: headerColor,
+          borderRadius: resolvedRadius,
+        ),
+        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+        child: Row(
+          children: [
+            // 드래그 핸들 (좌측)
+            ReorderableDragStartListener(
+              index: widget.index,
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.drag_indicator,
+                  color: iconColor.withValues(alpha: 0.7),
+                  size: 24,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            // 제목
+            Expanded(
+              child: Text(
+                widget.displayTitle ?? widget.subject.title,
+                style: TextStyle(
+                  color: textColor,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 18,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            // 펼침/접기 버튼 (우측)
+            IconButton(
+              icon: Icon(
+                expanded ? Icons.keyboard_arrow_down : Icons.keyboard_arrow_up,
+                color: iconColor,
+              ),
+              onPressed: _toggleExpanded,
+              tooltip: expanded ? '접기' : '펼치기',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return AnimatedContainer(
-      duration: Duration.zero,
+    return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(_editPanelRadius),
         boxShadow: expanded ? const [_editPanelShadow] : const [],
@@ -757,17 +902,8 @@ class _SubjectEditPanelState extends State<_SubjectEditPanel>
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // ========== 검은 헤더 (과목 이름 + 펼침 버튼) ==========
-              SubjectPanelHeader(
-                title: widget.displayTitle ?? widget.subject.title,
-                tags: const [], // 과목 수정 화면에서는 태그 표시 안 함
-                expanded: expanded,
-                onToggleExpanded: _toggleExpanded,
-                panelRadius: _editPanelRadius,
-                collapsedRadius: BorderRadius.circular(_editPanelRadius),
-                onLongPress: widget.onLongPress,
-                titleEndPadding: 8,
-              ),
+              // ========== 검은 헤더 (과목 이름 + 펼침 버튼 + 드래그 핸들) ==========
+              _buildDraggableHeader(),
 
               // ========== 강의 리스트 (펼쳤을 때만 표시) ==========
               SizeTransition(

--- a/frontend/lib/features/tags/tags_edit_screen.dart
+++ b/frontend/lib/features/tags/tags_edit_screen.dart
@@ -150,56 +150,146 @@ class _TagsEditScreenState extends State<TagsEditScreen> {
           children: [
             _buildThemeSelector(context),
             const SizedBox(height: 16),
-            _buildTagChips(),
-            const SizedBox(height: 16),
-            _buildEditForm(context),
-            const SizedBox(height: 24),
-            _buildDeleteButton(context),
+            _buildTagEditSection(context),
           ],
         ),
       ),
     );
   }
 
-  /// 테마 선택 카드 빌드
+  /// 테마 선택 카드 빌드 (라디오 버튼 + 색상 미리보기)
   Widget _buildThemeSelector(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               AppLocalizations.of(context).colorTheme,
-              style: const TextStyle(fontWeight: FontWeight.w700),
+              style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
             ),
             const SizedBox(height: 8),
-            Theme(
-              data: ThemeData(
-                useMaterial3: true,
-                brightness: Brightness.light, // 다크모드 자동 조정 방지
+            ...tagColorThemes.map((TagColorTheme theme) {
+              return _buildThemeRadioTile(context, theme);
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 개별 테마 라디오 타일 빌드
+  Widget _buildThemeRadioTile(BuildContext context, TagColorTheme theme) {
+    final isSelected = _currentTheme == theme.name;
+
+    return InkWell(
+      onTap: () {
+        setState(() {
+          _currentTheme = theme.name;
+        });
+        _applyThemeToAllTags();
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          children: [
+            // 라디오 버튼
+            // ignore: deprecated_member_use
+            Radio<String>(
+              value: theme.name,
+              // ignore: deprecated_member_use
+              groupValue: _currentTheme,
+              // ignore: deprecated_member_use
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() {
+                    _currentTheme = value;
+                  });
+                  _applyThemeToAllTags();
+                }
+              },
+            ),
+            const SizedBox(width: 4),
+            // 테마 이름
+            Expanded(
+              child: Text(
+                AppLocalizations.of(context).getThemeName(theme.name),
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
               ),
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: tagColorThemes.map((TagColorTheme theme) {
-                  return ChoiceChip(
-                    label: Text(
-                      AppLocalizations.of(context).getThemeName(theme.name),
-                      style: const TextStyle(color: Colors.black),
+            ),
+            const SizedBox(width: 4),
+            // 색상 미리보기 팔레트
+            Wrap(
+              spacing: 4,
+              children: theme.colors.map((colorInt) {
+                return Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    color: Color(colorInt),
+                    borderRadius: BorderRadius.circular(4),
+                    border: Border.all(color: Colors.grey.shade300, width: 0.5),
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(width: 2),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 태그 수정 섹션 (태그 칩 + 편집 폼 + 삭제 버튼)
+  Widget _buildTagEditSection(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              AppLocalizations.of(context).editingTags,
+              style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            _buildTagChips(),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _nameC,
+              decoration: InputDecoration(
+                labelText: AppLocalizations.of(context).tagName,
+                border: const OutlineInputBorder(),
+              ),
+              enableIMEPersonalizedLearning: false,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton(
+                    onPressed: _applyNameChange,
+                    child: Text(AppLocalizations.of(context).nameApply),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // 삭제 버튼을 버튼 행에 통합
+                if (_tags.isNotEmpty)
+                  Expanded(
+                    child: FilledButton.icon(
+                      style: FilledButton.styleFrom(
+                        backgroundColor: const Color.fromARGB(255, 231, 76, 60),
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: _deleteSelectedTag,
+                      label: Text(AppLocalizations.of(context).deleteTag),
                     ),
-                    selected: _currentTheme == theme.name,
-                    onSelected: (selected) {
-                      if (selected) {
-                        setState(() {
-                          _currentTheme = theme.name;
-                        });
-                        _applyThemeToAllTags();
-                      }
-                    },
-                  );
-                }).toList(),
-              ),
+                  ),
+              ],
             ),
           ],
         ),
@@ -243,67 +333,6 @@ class _TagsEditScreenState extends State<TagsEditScreen> {
       tag: _tags[index],
       selected: isSelected,
       onSelected: (_) => _syncForm(index),
-    );
-  }
-
-  /// 태그 이름 편집 폼 빌드
-  Widget _buildEditForm(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _nameC,
-              decoration: InputDecoration(
-                labelText: AppLocalizations.of(context).tagName,
-              ),
-              enableIMEPersonalizedLearning: false,
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Expanded(
-                  child: FilledButton(
-                    onPressed: _applyNameChange,
-                    child: Text(AppLocalizations.of(context).apply),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: _cancelNameChange,
-                    child: Text(AppLocalizations.of(context).cancel),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// 태그 삭제 버튼 빌드
-  Widget _buildDeleteButton(BuildContext context) {
-    if (_tags.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    return Center(
-      child: SizedBox(
-        width: MediaQuery.of(context).size.width * 0.4,
-        child: FilledButton.icon(
-          style: FilledButton.styleFrom(
-            backgroundColor: Colors.red,
-            foregroundColor: Colors.white,
-          ),
-          onPressed: _deleteSelectedTag,
-          icon: const Icon(Icons.delete),
-          label: Text(AppLocalizations.of(context).deleteTag),
-        ),
-      ),
     );
   }
 
@@ -385,22 +414,6 @@ class _TagsEditScreenState extends State<TagsEditScreen> {
       }
     }
     return false;
-  }
-
-  /// 태그 이름 변경 취소
-  ///
-  /// 입력 필드를 현재 선택된 태그의 이름으로 되돌립니다.
-  void _cancelNameChange() {
-    if (_tags.isEmpty) {
-      return;
-    }
-
-    // 한글 입력 문제 방지를 위해 프레임 이후 실행
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        _nameC.text = _tags[_selected].name;
-      }
-    });
   }
 
   /// 선택된 태그 삭제

--- a/frontend/test/data/hive_manager_test.dart
+++ b/frontend/test/data/hive_manager_test.dart
@@ -139,7 +139,6 @@ void main() {
           accessibilityReduceMotion: true,
           accessibilityEmphasizeCaptions: true,
           ttsGender: '남성',
-          ttsSpeed: '보통',
           tagColorTheme: '파스텔',
         ),
         subjects: subjects,
@@ -190,7 +189,7 @@ void main() {
         reduceMotion: false,
         emphasizeCaptions: false,
       );
-      await manager.updateTts(gender: '여성', speed: '빠르게');
+      await manager.updateTts(gender: '여성');
       await manager.updateTagColorTheme('비비드');
 
       final saved = appBox.get('main');
@@ -201,7 +200,6 @@ void main() {
       expect(manager.settings.accessibilityReduceMotion, isFalse);
       expect(manager.settings.accessibilityEmphasizeCaptions, isFalse);
       expect(manager.settings.ttsGender, '여성');
-      expect(manager.settings.ttsSpeed, '빠르게');
       expect(manager.settings.tagColorTheme, '비비드');
       expect(saved?.settings.theme, 'light');
       expect(notificationCount, greaterThan(0));

--- a/frontend/test/data/hive_models.g_test.dart
+++ b/frontend/test/data/hive_models.g_test.dart
@@ -83,7 +83,6 @@ void main() {
           accessibilityReduceMotion: true,
           accessibilityEmphasizeCaptions: false,
           ttsGender: '여성',
-          ttsSpeed: '빠르게',
           tagColorTheme: '비비드',
         ),
         subjects: {
@@ -142,14 +141,12 @@ void main() {
         accessibilityReduceMotion: true,
         accessibilityEmphasizeCaptions: false,
         ttsGender: '남성',
-        ttsSpeed: '느리게',
         tagColorTheme: '파스텔',
       );
 
       final result = _roundTrip(bundle, bundle.appSettings, original);
       expect(result.theme, 'light');
       expect(result.accessibilityReduceMotion, isTrue);
-      expect(result.ttsSpeed, '느리게');
       expect(result.tagColorTheme, '파스텔');
     });
   });

--- a/frontend/test/data/hive_models_test.dart
+++ b/frontend/test/data/hive_models_test.dart
@@ -74,7 +74,6 @@ void main() {
       expect(settings.accessibilityReduceMotion, isFalse);
       expect(settings.accessibilityEmphasizeCaptions, isTrue);
       expect(settings.ttsGender, '남성');
-      expect(settings.ttsSpeed, '보통');
       expect(settings.tagColorTheme, '봄');
     });
 

--- a/frontend/test/features/settings/accessibility_mode_test.dart
+++ b/frontend/test/features/settings/accessibility_mode_test.dart
@@ -21,7 +21,6 @@ class FakeAppSettings implements AppSettings {
     this.accessibilityReduceMotion = false,
     this.accessibilityEmphasizeCaptions = false,
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.tagColorTheme = '파스텔',
     this.hasCompletedTutorial = true,
   });
@@ -43,9 +42,6 @@ class FakeAppSettings implements AppSettings {
 
   @override
   String ttsGender;
-
-  @override
-  String ttsSpeed;
 
   @override
   String tagColorTheme;

--- a/frontend/test/features/settings/language_screen_test.dart
+++ b/frontend/test/features/settings/language_screen_test.dart
@@ -17,7 +17,6 @@ class FakeAppSettings implements AppSettings {
     this.accessibilityReduceMotion = false,
     this.accessibilityEmphasizeCaptions = true,
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.tagColorTheme = '파스텔',
     this.hasCompletedTutorial = true,
   });
@@ -39,9 +38,6 @@ class FakeAppSettings implements AppSettings {
 
   @override
   String ttsGender;
-
-  @override
-  String ttsSpeed;
 
   @override
   String tagColorTheme;

--- a/frontend/test/features/settings/language_screen_test.dart
+++ b/frontend/test/features/settings/language_screen_test.dart
@@ -160,6 +160,12 @@ class FakeHiveManager with ChangeNotifier implements HiveManager {
   Future<void> updateSubjectTags(String id, List<String> tagIds) async {}
 
   @override
+  List<String> get subjectOrder => [];
+
+  @override
+  Future<void> updateSubjectOrder(List<String> newOrder) async {}
+
+  @override
   List<HiveTag> getTags() => [];
 
   @override

--- a/frontend/test/features/settings/tts_screen_test.dart
+++ b/frontend/test/features/settings/tts_screen_test.dart
@@ -14,7 +14,6 @@ import 'package:re_view/features/settings/tts_screen.dart';
 class FakeAppSettings implements AppSettings {
   FakeAppSettings({
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.theme = 'system',
     this.language = 'ko',
     this.accessibilityHighContrast = false,
@@ -26,8 +25,6 @@ class FakeAppSettings implements AppSettings {
 
   @override
   String ttsGender;
-  @override
-  String ttsSpeed;
 
   @override
   String theme;
@@ -47,39 +44,30 @@ class FakeAppSettings implements AppSettings {
 
 /// HiveManager 인터페이스를 구현하는 Fake 클래스
 class FakeHiveManager with ChangeNotifier implements HiveManager {
-  FakeHiveManager({String initialGender = '남성', String initialSpeed = '보통'}) {
-    _fakeSettings = FakeAppSettings(
-      ttsGender: initialGender,
-      ttsSpeed: initialSpeed,
-    );
+  FakeHiveManager({String initialGender = '남성'}) {
+    _fakeSettings = FakeAppSettings(ttsGender: initialGender);
   }
 
   late FakeAppSettings _fakeSettings;
 
   bool updateTtsCalled = false;
   String? lastGender;
-  String? lastSpeed;
 
   @override
   AppSettings get settings => _fakeSettings;
 
   @override
-  Future<void> updateTts({String? gender, String? speed}) async {
+  Future<void> updateTts({String? gender}) async {
     updateTtsCalled = true;
     if (gender != null) {
       _fakeSettings.ttsGender = gender;
       lastGender = gender;
-    }
-    if (speed != null) {
-      _fakeSettings.ttsSpeed = speed;
-      lastSpeed = speed;
     }
   }
 
   void resetCallHistory() {
     updateTtsCalled = false;
     lastGender = null;
-    lastSpeed = null;
   }
 
   // Tutorial methods (not used in this test)
@@ -149,6 +137,10 @@ class FakeHiveManager with ChangeNotifier implements HiveManager {
   ) async {}
   @override
   Future<void> updateSubjectTags(String id, List<String> tagIds) async {}
+  @override
+  List<String> get subjectOrder => [];
+  @override
+  Future<void> updateSubjectOrder(List<String> newOrder) async {}
   @override
   List<HiveTag> getTags() => [];
   @override
@@ -241,11 +233,6 @@ void main() {
     return text.style?.fontWeight == FontWeight.w600;
   }
 
-  bool isSpeedSelected(WidgetTester tester, String label) {
-    final text = tester.widget<Text>(find.text(label));
-    return text.style?.fontWeight == FontWeight.w600;
-  }
-
   group('tts_screen.dart: Widget Test', () {
     group('1. UI Initial State Verification (Mock Data -> UI)', () {
       testWidgets('메인 Scaffold가 렌더링되어야 함', (tester) async {
@@ -254,27 +241,19 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsNothing);
       });
 
-      testWidgets('설정이 "남성", "보통"일 때 UI에 반영되어야 함', (tester) async {
+      testWidgets('설정이 "남성"일 때 UI에 반영되어야 함', (tester) async {
         await pumpTtsScreen(tester, locale: const Locale('ko'));
 
         expect(isGenderSelected(tester, '남성'), isTrue);
         expect(isGenderSelected(tester, '여성'), isFalse);
-        expect(isSpeedSelected(tester, '보통'), isTrue);
-        expect(isSpeedSelected(tester, '빠르게'), isFalse);
-        expect(isSpeedSelected(tester, '느리게'), isFalse);
       });
 
-      testWidgets('설정이 "여성", "빠르게"일 때 UI에 반영되어야 함', (tester) async {
-        fakeHiveManager = FakeHiveManager(
-          initialGender: '여성',
-          initialSpeed: '빠르게',
-        );
+      testWidgets('설정이 "여성"일 때 UI에 반영되어야 함', (tester) async {
+        fakeHiveManager = FakeHiveManager(initialGender: '여성');
         await pumpTtsScreen(tester, locale: const Locale('ko'));
 
         expect(isGenderSelected(tester, '여성'), isTrue);
         expect(isGenderSelected(tester, '남성'), isFalse);
-        expect(isSpeedSelected(tester, '빠르게'), isTrue);
-        expect(isSpeedSelected(tester, '보통'), isFalse);
       });
 
       testWidgets('한국어(ko) 로케일일 때 한국어 라벨이 표시되어야 함', (tester) async {
@@ -347,32 +326,6 @@ void main() {
         expect(fakeHiveManager.lastGender, '여성');
       });
 
-      testWidgets('"빠르게" 버튼 탭 시 updateTts(speed: "빠르게") 호출 및 UI 변경', (
-        tester,
-      ) async {
-        await pumpTtsScreen(tester, locale: const Locale('ko'));
-
-        await tester.tap(find.text('빠르게'));
-        await tester.pumpAndSettle();
-
-        expect(fakeHiveManager.updateTtsCalled, isTrue);
-        expect(fakeHiveManager.lastSpeed, '빠르게');
-        expect(isSpeedSelected(tester, '빠르게'), isTrue);
-      });
-
-      testWidgets('"느리게" 버튼 탭 시 updateTts(speed: "느리게") 호출 및 UI 변경', (
-        tester,
-      ) async {
-        await pumpTtsScreen(tester, locale: const Locale('ko'));
-
-        await tester.tap(find.text('느리게'));
-        await tester.pumpAndSettle();
-
-        expect(fakeHiveManager.updateTtsCalled, isTrue);
-        expect(fakeHiveManager.lastSpeed, '느리게');
-        expect(isSpeedSelected(tester, '느리게'), isTrue);
-      });
-
       testWidgets('AppBar 닫기 버튼 탭 시 Navigator.pop 호출', (tester) async {
         await pumpTtsScreen(tester);
 
@@ -380,25 +333,6 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(fakeNavigatorObserver.popCalled, isTrue);
-      });
-    });
-
-    group('3. Static Method Unit Tests (speedToRate)', () {
-      test('TtsScreen.speedToRate("빠르게")는 1.5를 반환해야 함', () {
-        expect(TtsScreen.speedToRate('빠르게'), 1.5);
-      });
-
-      test('TtsScreen.speedToRate("보통")는 1.0을 반환해야 함', () {
-        expect(TtsScreen.speedToRate('보통'), 1.0);
-      });
-
-      test('TtsScreen.speedToRate("느리게")는 0.7을 반환해야 함', () {
-        expect(TtsScreen.speedToRate('느리게'), 0.7);
-      });
-
-      test('TtsScreen.speedToRate("other")는 1.0 (기본값)을 반환해야 함', () {
-        expect(TtsScreen.speedToRate('some_other_value'), 1.0);
-        expect(TtsScreen.speedToRate(''), 1.0);
       });
     });
   });

--- a/frontend/test/features/subjects/subjects_edit_screen_test.dart
+++ b/frontend/test/features/subjects/subjects_edit_screen_test.dart
@@ -21,7 +21,6 @@ class FakeAppSettings implements AppSettings {
     this.accessibilityReduceMotion = false,
     this.accessibilityEmphasizeCaptions = false,
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.tagColorTheme = '봄',
     this.hasCompletedTutorial = false,
   });
@@ -40,8 +39,6 @@ class FakeAppSettings implements AppSettings {
   String theme;
   @override
   String ttsGender;
-  @override
-  String ttsSpeed;
   @override
   bool hasCompletedTutorial;
 }

--- a/frontend/test/features/tags/tags_edit_screen_test.dart
+++ b/frontend/test/features/tags/tags_edit_screen_test.dart
@@ -21,7 +21,6 @@ class FakeAppSettings implements AppSettings {
     this.accessibilityReduceMotion = false,
     this.accessibilityEmphasizeCaptions = false,
     this.ttsGender = '남성',
-    this.ttsSpeed = '보통',
     this.tagColorTheme = '봄', // 기본값 '봄'
     this.hasCompletedTutorial = false,
   });
@@ -40,8 +39,6 @@ class FakeAppSettings implements AppSettings {
   String theme;
   @override
   String ttsGender;
-  @override
-  String ttsSpeed;
   @override
   bool hasCompletedTutorial;
 }


### PR DESCRIPTION
## 📝 Description
This PR introduces the ability for users to manually reorder their subjects via a drag-and-drop interface. This custom order is now persisted in the Hive database and respected when fetching/displaying the subject list.

This implementation touches four main areas:
1.  **Data Model:** The `AppData` Hive model is updated to store a list of subject IDs (`subjectOrder`).
2.  **Data Logic:** `HiveManager` is updated to handle reading, writing, and updating this order (including adding new subjects to the top and removing deleted subjects).
3.  **UI:** The `SubjectsEditScreen` now uses a `ReorderableListView` to allow drag-and-drop reordering.
4.  **Tests:** Test mocks are updated to reflect the new `HiveManager` methods.

Additionally, this PR includes a separate UI refactor for the `TagsEditScreen` (improving theme selection) and a cleanup removing the deprecated TTS speed feature.

---

## 🔨 Changes Made
* **Subject Reordering (Core Feature)**
    * `[Data]` Added `subjectOrder` field (HiveField 5) to the `AppData` model and regenerated adapters.
    * `[Logic]` Implemented `subjectOrder` getter and `updateSubjectOrder` method in `HiveManager`.
    * `[Logic]` Modified `getSubjects` to sort based on the stored `subjectOrder`. It falls back to alphabetical order if no custom order exists.
    * `[Logic]` Updated `createSubject` to insert new subjects at the beginning of the list (top) and `deleteSubject` to remove them from the order list.
    * `[UI]` Replaced `ListView` with `ReorderableListView` in `SubjectsEditScreen` to enable drag-and-drop.
    * `[UI]` Added a dedicated drag handle (`Icons.drag_indicator`) to solve gesture conflicts.
    * `[UI]` Implemented a "working copy" pattern (`_workingSubjectOrder`) so changes are only saved on confirmation ("수정 완료").
    * `[Fix]` Fixed subject panel animation color and delete button visibility.
    * `[Test]` Updated `FakeHiveManager` mocks to include new subject ordering methods, fixing test compilation errors.

* **Other Changes**
    * `[Refactor]` Refactored `TagsEditScreen`:
        * Replaced `ChoiceChip` with `Radio` buttons for theme selection.
        * Added color palette previews for each theme.
        * Consolidated the UI into a single `Card` and adjusted the layout.
    * `[Fix]` Removed the `ttsSpeed` variable and related UI from `TtsScreen` and tests.
    * `[i18n]` Added a new localization string for '이름 적용' (Apply Name).

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
*(Recommended: Add a GIF/video of the drag-and-drop reordering in action)*

---

## 🔗 Related Issues / PRs
Fixes #

---

## 👥 Reviewers
- @del2090 
- @soarhigh03 

---

## 📌 Notes for Reviewers
* The primary focus is the subject reordering functionality. Please pay close attention to the logic in `HiveManager` for handling order updates (create, delete, reorder) and the fallback sorting.
* The `TagsEditScreen` refactor and TTS speed removal are included here but are functionally separate from the main feature.