### PR TITLE
Refactor home/search screens for efficient caching and removal of deprecated class

### DIFF
--- a/frontend/lib/core/thumbnail_cache_manager.dart
+++ b/frontend/lib/core/thumbnail_cache_manager.dart
@@ -1,0 +1,71 @@
+import 'dart:collection';
+import 'package:flutter/foundation.dart';
+import 'package:pdfx/pdfx.dart';
+
+/// LRU캐시를 사용한 썸네일 캐시 매니저
+/// HiveLecture의 첫 페이지 썸네일을 메모리에 caching
+
+class ThumbnailCacheManager {
+  ThumbnailCacheManager._();
+
+  static final ThumbnailCacheManager instance = ThumbnailCacheManager._();
+
+  static const int _maxCacheSize = 50;
+
+  /// LRU 캐시: lectureId -> PdfPageImage
+  final LinkedHashMap<String, PdfPageImage> _cache = LinkedHashMap();
+
+  /// 캐시에서 썸네일 가져오기
+  /// 캐시에 존재하면 해당 항목을 가장 최근 사용으로 이동시키고 반환
+  PdfPageImage? get(String lectureId) {
+    if (!_cache.containsKey(lectureId)) {
+      return null;
+    }
+
+    // LRU: 접근한 항목을 맨 뒤로 이동 (가장 최근 사용)
+    final image = _cache.remove(lectureId)!;
+    _cache[lectureId] = image;
+
+    return image;
+  }
+
+  /// 캐시에 썸네일 추가
+  /// 캐시 크기가 최대치를 초과하면 가장 오래된 항목 제거
+  void put(String lectureId, PdfPageImage image) {
+    if (_cache.containsKey(lectureId)) {
+      _cache.remove(lectureId);
+    }
+
+    // 캐시 크기 제한 확인
+    if (_cache.length >= _maxCacheSize) {
+      // 가장 오래된 항목 제거 (맨 앞)
+      final oldestKey = _cache.keys.first;
+      _cache.remove(oldestKey);
+      debugPrint('🗑️ Thumbnail cache evicted: $oldestKey');
+    }
+
+    // 새 항목 추가 (맨 뒤)
+    _cache[lectureId] = image;
+    debugPrint('Thumbnail cached: $lectureId (total: ${_cache.length})');
+  }
+
+  /// 특정 강의의 썸네일을 캐시에서 제거
+  void remove(String lectureId) {
+    if (_cache.containsKey(lectureId)) {
+      _cache.remove(lectureId);
+      debugPrint('Thumbnail removed from cache: $lectureId');
+    }
+  }
+
+  /// 캐시 전체 삭제
+  void clear() {
+    _cache.clear();
+    debugPrint('Thumbnail cache cleared');
+  }
+
+  /// 현재 캐시 크기
+  int get size => _cache.length;
+
+  /// 캐시에 특정 강의 ID가 존재하는지 확인
+  bool contains(String lectureId) => _cache.containsKey(lectureId);
+}

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:pdfx/pdfx.dart';
 import 'package:re_view/core/localization/app_localizations.dart';
 import 'package:re_view/core/theme/color_scheme.dart';
+import 'package:re_view/core/thumbnail_cache_manager.dart';
 import 'package:re_view/data/models.dart';
 import 'package:re_view/data/hive_models.dart';
 import 'package:re_view/data/hive_manager.dart';
@@ -382,7 +383,7 @@ class LectureCard extends StatefulWidget {
 class _LectureCardState extends State<LectureCard> {
   PdfDocument? _pdfDocument;
   PdfPage? _pdfPage;
-  PdfPageImage? _cachedImage; // 렌더링된 이미지 캐싱
+  PdfPageImage? _cachedImage; // 렌더링된 이미지 (로컬 참조용)
   bool _isLoading = true;
   String? _error;
 
@@ -396,7 +397,8 @@ class _LectureCardState extends State<LectureCard> {
   void didUpdateWidget(LectureCard oldWidget) {
     super.didUpdateWidget(oldWidget);
     // 강의 내용이 변경되면 PDF 다시 로드
-    if (oldWidget.lec.slidePath != widget.lec.slidePath) {
+    if (oldWidget.lec.slidePath != widget.lec.slidePath ||
+        oldWidget.lec.id != widget.lec.id) {
       _pdfPage?.close();
       _pdfDocument?.close();
       _pdfDocument = null;
@@ -414,6 +416,22 @@ class _LectureCardState extends State<LectureCard> {
       return;
     }
 
+    // 1. 먼저 글로벌 캐시에서 확인
+    final cacheManager = ThumbnailCacheManager.instance;
+    final cachedImage = cacheManager.get(widget.lec.id);
+
+    if (cachedImage != null) {
+      // 캐시에 있으면 바로 사용
+      if (mounted) {
+        setState(() {
+          _cachedImage = cachedImage;
+          _isLoading = false;
+        });
+      }
+      return;
+    }
+
+    // 2. 캐시에 없으면 PDF 로드 및 렌더링
     try {
       // assets 경로인지 파일 시스템 경로인지 확인
       final bool isAsset = widget.lec.slidePath!.startsWith('assets/');
@@ -427,6 +445,12 @@ class _LectureCardState extends State<LectureCard> {
         height: page.height * 2,
         format: PdfPageImageFormat.png,
       );
+
+      if (image != null) {
+        // 3. 글로벌 캐시에 저장
+        cacheManager.put(widget.lec.id, image);
+      }
+
       if (mounted) {
         setState(() {
           _pdfDocument = document;

--- a/frontend/lib/features/search/search_screen.dart
+++ b/frontend/lib/features/search/search_screen.dart
@@ -2,7 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:re_view/app_router.dart';
 import 'package:re_view/core/localization/app_localizations.dart';
-import 'package:re_view/data/models.dart';
+import 'package:re_view/data/hive_models.dart';
 import 'package:re_view/data/hive_manager.dart';
 
 /// 검색 화면
@@ -18,7 +18,7 @@ enum SearchScope { lecture, week, subject }
 class _SearchScreenState extends State<SearchScreen> {
   final _searchController = TextEditingController();
   List<String> _recentSearches = [];
-  List<Lecture> _searchResults = [];
+  List<HiveLecture> _searchResults = [];
   bool _isSearching = false;
   SearchScope _searchScope = SearchScope.lecture;
 
@@ -77,15 +77,12 @@ class _SearchScreenState extends State<SearchScreen> {
     }
 
     final hive = HiveManager.instance;
-    final subjects = hive.getSubjects().map((s) => s.toSubject()).toList();
+    final subjects = hive.getSubjects();
 
     // 모든 과목의 모든 강의에서 검색
-    final allLectures = <Lecture>[];
+    final allLectures = <HiveLecture>[];
     for (final subject in subjects) {
-      final lectures = hive
-          .getLecturesBySubject(subject.id)
-          .map((l) => l.toLecture())
-          .toList();
+      final lectures = hive.getLecturesBySubject(subject.id);
       allLectures.addAll(lectures);
     }
 
@@ -105,7 +102,7 @@ class _SearchScreenState extends State<SearchScreen> {
         case SearchScope.subject:
           final subject = subjects.firstWhere(
             (s) => s.id == lec.subjectId,
-            orElse: () => const Subject(id: '', title: ''),
+            orElse: () => HiveSubject(id: '', title: ''),
           );
           return subject.title.toLowerCase().contains(searchQuery);
       }
@@ -284,10 +281,7 @@ class _SearchScreenState extends State<SearchScreen> {
     }
 
     // 과목 목록을 한 번만 가져오기
-    final subjects = HiveManager.instance
-        .getSubjects()
-        .map((s) => s.toSubject())
-        .toList();
+    final subjects = HiveManager.instance.getSubjects();
 
     return ListView.separated(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -297,7 +291,7 @@ class _SearchScreenState extends State<SearchScreen> {
         final lecture = _searchResults[index];
         final subject = subjects.firstWhere(
           (s) => s.id == lecture.subjectId,
-          orElse: () => const Subject(id: '', title: ''),
+          orElse: () => HiveSubject(id: '', title: ''),
         );
 
         return ListTile(


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->
Refactor home/search screens for efficient caching and removal of deprecated class
---

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Implemented thumbnail cache manager to unify caching of pdf thumbnails among Home Screen and player screen (accessible with final thumbnail = ThumbnailCacheManager.instance.get(lecture.id);)
- Also removed list of Lecture class in search_screen, as Lecture class is deprecated - replaced it all with HiveLecture, which is a bit heavier but for overall code maintenance

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [ ] Added/updated tests
- [x] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @Whitemoons 
- @Soo-03 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->

@Soo-03 Lecture class is also still being used in subjects_edit_screen.dart. Please review and refactor asap.