### PR TITLE
Delays audio playback until after layout

### DIFF
--- a/frontend/lib/features/player/player_controller.dart
+++ b/frontend/lib/features/player/player_controller.dart
@@ -149,10 +149,8 @@ class PlayerController extends ChangeNotifier {
     // 스크롤 리스너 설정
     _setupScrollListener();
 
-    // 오디오 로드 및 재생 (기본: TTS)
+    // 오디오 로드 (재생은 외부에서 startPlayback() 호출)
     await _audioService.loadAudio(audioPath);
-
-    _audioService.play(); // await 제거 - fire-and-forget
   }
 
   Future<void> _loadPdfDocument(
@@ -295,6 +293,11 @@ class PlayerController extends ChangeNotifier {
   }
 
   // ========== 재생 제어 메서드 ==========
+
+  /// 초기 재생 시작 (OrientationBuilder가 안정화된 후 호출)
+  Future<void> startPlayback() async {
+    await _audioService.play();
+  }
 
   Future<void> playPause() async {
     if (isPlaying.value) {

--- a/frontend/lib/features/player/player_screen.dart
+++ b/frontend/lib/features/player/player_screen.dart
@@ -224,6 +224,13 @@ class _PlayerScreenState extends State<PlayerScreen>
         setState(() {
           _isLoading = false;
         });
+
+        // OrientationBuilder와 PdfView가 완전히 mount된 후 재생 시작
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            _controller.startPlayback();
+          }
+        });
       }
     } catch (e) {
       // 예상하지 못한 에러 처리


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---

Delays the start of audio playback until after the OrientationBuilder and PdfView widgets are fully mounted. This ensures that the UI is stable before playback begins, preventing potential issues with layout or rendering.

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Delay audio playback
  - It starts after widgets are fully mounted

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @kwakmeensoo 
- @

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
