### PR TITLE
Update loading widget to 1) show error widget when aborted, 2) show loading-complete widget after frontend logic is finished

### DIFF
--- a/frontend/lib/core/lecture_loading_service.dart
+++ b/frontend/lib/core/lecture_loading_service.dart
@@ -58,6 +58,9 @@ class LectureLoadingService extends ChangeNotifier {
   bool _bubbleOnRight = true;
   double _bubbleX = 24.0; // X position from left edge
   double _bubbleY = 24.0; // Y position from bottom edge
+  bool _hasError = false; // 에러 발생 여부
+  String _errorTitle = ''; // 에러 제목
+  String _errorMessage = ''; // 에러 상세 메시지
 
   /// 현재 로딩 중인지 여부
   bool get isLoading => _isLoading;
@@ -89,6 +92,15 @@ class LectureLoadingService extends ChangeNotifier {
   /// 버블의 Y 위치 (하단 가장자리로부터의 거리)
   double get bubbleY => _bubbleY;
 
+  /// 에러 발생 여부
+  bool get hasError => _hasError;
+
+  /// 에러 제목
+  String get errorTitle => _errorTitle;
+
+  /// 에러 상세 메시지
+  String get errorMessage => _errorMessage;
+
   /// 취소 콜백 등록
   void setOnCancel(VoidCallback? callback) {
     _onCancel = callback;
@@ -115,6 +127,9 @@ class LectureLoadingService extends ChangeNotifier {
     _isCancelled = false;
     _isCollapsed = false;
     _bubbleOnRight = true;
+    _hasError = false;
+    _errorTitle = '';
+    _errorMessage = '';
 
     // 주기적으로 메시지 변경 (3-5초마다)
     _startMessageTimer();
@@ -202,19 +217,32 @@ class LectureLoadingService extends ChangeNotifier {
     _onCancel = null;
     _isCollapsed = false;
     _bubbleOnRight = true;
+    _hasError = false;
+    _errorTitle = '';
+    _errorMessage = '';
     notifyListeners();
     _clearState();
   }
 
   /// 에러 발생 시
-  void setError(String errorMessage) {
+  void setError({String? errorTitle, String? errorMessage}) {
     _messageTimer?.cancel();
+    _hasError = true;
     final language = HiveManager.instance.settings.language;
-    _message = language == 'ko' ? '오류가 발생했어요' : 'An error occurred';
-    notifyListeners();
 
-    // 3초 후 자동으로 숨김
-    Future.delayed(const Duration(seconds: 3), hideLoading);
+    // 에러 제목 설정
+    _errorTitle =
+        errorTitle ?? (language == 'ko' ? '오류가 발생했습니다' : 'An error occurred');
+
+    // 에러 메시지 설정
+    _errorMessage =
+        errorMessage ??
+        (language == 'ko'
+            ? '네트워크 설정을 확인하고, 조금 뒤에 다시 시도해주세요.'
+            : 'Please check your network settings and try again later.');
+
+    notifyListeners();
+    _saveState();
   }
 
   /// 강의 생성 취소

--- a/frontend/lib/core/lecture_loading_service.dart
+++ b/frontend/lib/core/lecture_loading_service.dart
@@ -61,6 +61,7 @@ class LectureLoadingService extends ChangeNotifier {
   bool _hasError = false; // 에러 발생 여부
   String _errorTitle = ''; // 에러 제목
   String _errorMessage = ''; // 에러 상세 메시지
+  bool _isCompleted = false; // 완료 뷰 표시 여부
 
   /// 현재 로딩 중인지 여부
   bool get isLoading => _isLoading;
@@ -101,6 +102,9 @@ class LectureLoadingService extends ChangeNotifier {
   /// 에러 상세 메시지
   String get errorMessage => _errorMessage;
 
+  /// 완료 위젯 노출 여부
+  bool get isCompleted => _isCompleted;
+
   /// 취소 콜백 등록
   void setOnCancel(VoidCallback? callback) {
     _onCancel = callback;
@@ -130,6 +134,7 @@ class LectureLoadingService extends ChangeNotifier {
     _hasError = false;
     _errorTitle = '';
     _errorMessage = '';
+    _isCompleted = false;
 
     // 주기적으로 메시지 변경 (3-5초마다)
     _startMessageTimer();
@@ -201,6 +206,7 @@ class LectureLoadingService extends ChangeNotifier {
     final language = HiveManager.instance.settings.language;
     _message = language == 'ko' ? '강의 생성 완료!' : 'Lecture created!';
     _lectureId = lectureId;
+    _isCompleted = true;
     notifyListeners();
     _saveState();
   }
@@ -220,6 +226,7 @@ class LectureLoadingService extends ChangeNotifier {
     _hasError = false;
     _errorTitle = '';
     _errorMessage = '';
+    _isCompleted = false;
     notifyListeners();
     _clearState();
   }
@@ -304,6 +311,7 @@ class LectureLoadingService extends ChangeNotifier {
   static const _keyBubbleOnRight = 'lecture_loading_bubble_on_right';
   static const _keyBubbleX = 'lecture_loading_bubble_x';
   static const _keyBubbleY = 'lecture_loading_bubble_y';
+  static const _keyIsCompleted = 'lecture_loading_is_completed';
 
   /// 상태를 SharedPreferences에 저장
   Future<void> _saveState() async {
@@ -317,6 +325,7 @@ class LectureLoadingService extends ChangeNotifier {
       await prefs.setBool(_keyBubbleOnRight, _bubbleOnRight);
       await prefs.setDouble(_keyBubbleX, _bubbleX);
       await prefs.setDouble(_keyBubbleY, _bubbleY);
+      await prefs.setBool(_keyIsCompleted, _isCompleted);
     } catch (e) {
       debugPrint('Failed to save loading state: $e');
     }
@@ -334,6 +343,7 @@ class LectureLoadingService extends ChangeNotifier {
       _bubbleOnRight = prefs.getBool(_keyBubbleOnRight) ?? true;
       _bubbleX = prefs.getDouble(_keyBubbleX) ?? 24.0;
       _bubbleY = prefs.getDouble(_keyBubbleY) ?? 24.0;
+      _isCompleted = prefs.getBool(_keyIsCompleted) ?? false;
 
       // 복원 후 UI 업데이트
       if (_isLoading) {
@@ -356,6 +366,7 @@ class LectureLoadingService extends ChangeNotifier {
       await prefs.remove(_keyBubbleOnRight);
       await prefs.remove(_keyBubbleX);
       await prefs.remove(_keyBubbleY);
+      await prefs.remove(_keyIsCompleted);
     } catch (e) {
       debugPrint('Failed to clear loading state: $e');
     }

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -171,61 +171,80 @@ Future<String?> requestLecture(
   }
 
   // Use the injected client to send
-  final streamed = await client
-      .send(req)
-      .timeout(
-        const Duration(minutes: 10),
-        onTimeout: () {
-          throw Exception(
-            'Server connection timeout - Please check if server is running',
-          );
-        },
-      );
-
-  // read chunked SSE-style body
-  final stream = streamed.stream.transform(utf8.decoder);
-
-  String? jobId;
   try {
-    await for (final chunk in stream) {
-      // 취소 확인
-      if (LectureLoadingService.instance.isCancelled) {
-        return null;
-      }
+    final streamed = await client
+        .send(req)
+        .timeout(
+          const Duration(minutes: 10),
+          onTimeout: () {
+            throw Exception(
+              'Server connection timeout - Please check if server is running',
+            );
+          },
+        );
 
-      final lines = chunk.split('\n');
-      for (final line in lines) {
-        if (line.startsWith('data: ')) {
-          final jsonData = line.substring(6);
-          final data = jsonDecode(jsonData) as Map<String, dynamic>;
+    // read chunked SSE-style body
+    final stream = streamed.stream
+        .transform(utf8.decoder)
+        .timeout(
+          const Duration(seconds: 30), // 30초 동안 업데이트가 없으면 타임아웃
+          onTimeout: (sink) {
+            debugPrint(
+              'Stream timeout - No updates from server for 30 seconds',
+            );
+            sink.addError(Exception('서버로부터 응답이 없습니다'));
+          },
+        );
 
-          jobId = data['job_id'] as String;
+    String? jobId;
+    try {
+      await for (final chunk in stream) {
+        // 취소 확인
+        if (LectureLoadingService.instance.isCancelled) {
+          return null;
+        }
 
-          // 서버가 0-100 범위로 보낼 수 있으므로 변환
-          final rawProgress = data['progress'];
-          final progress = rawProgress is int
-              ? (rawProgress / 100.0)
-              : (rawProgress as double) > 1.0
-              ? rawProgress / 100.0
-              : rawProgress;
+        final lines = chunk.split('\n');
+        for (final line in lines) {
+          if (line.startsWith('data: ')) {
+            final jsonData = line.substring(6);
+            final data = jsonDecode(jsonData) as Map<String, dynamic>;
 
-          final message = data['message'] as String;
+            jobId = data['job_id'] as String;
 
-          await onProgress(progress, message, titleText, order, audioCount);
+            // 서버가 0-100 범위로 보낼 수 있으므로 변환
+            final rawProgress = data['progress'];
+            final progress = rawProgress is int
+                ? (rawProgress / 100.0)
+                : (rawProgress as double) > 1.0
+                ? rawProgress / 100.0
+                : rawProgress;
 
-          if (data['status'] == 'completed') {
-            return jobId;
-          } else if (data['status'] == 'failed') {
-            return null;
+            final message = data['message'] as String;
+
+            await onProgress(progress, message, titleText, order, audioCount);
+
+            if (data['status'] == 'completed') {
+              return jobId;
+            } else if (data['status'] == 'failed') {
+              LectureLoadingService.instance.setError();
+              return null;
+            }
           }
         }
       }
+    } catch (e) {
+      debugPrint('Error during lecture request stream processing: $e');
+      LectureLoadingService.instance.setError();
+      return null;
     }
-  } catch (_) {
+
+    return jobId;
+  } catch (e) {
+    debugPrint('Error during lecture request: $e');
+    LectureLoadingService.instance.setError();
     return null;
   }
-
-  return jobId;
 }
 
 Future<String?> downloadResult(
@@ -254,9 +273,13 @@ Future<String?> downloadResult(
 
       return savePath;
     } else {
+      debugPrint('Failed to download result: ${response.statusCode}');
+      LectureLoadingService.instance.setError();
       return null;
     }
-  } catch (_) {
+  } catch (e) {
+    debugPrint('Error during download: $e');
+    LectureLoadingService.instance.setError();
     return null;
   }
 }
@@ -367,13 +390,20 @@ Future<List<String>?> fetchLecture(
     return null;
   }
 
-  final filePaths = await unzipResult(zipPath, titleText, order);
+  try {
+    final filePaths = await unzipResult(zipPath, titleText, order);
 
-  if (filePaths == null) {
+    if (filePaths == null) {
+      LectureLoadingService.instance.setError();
+      return null;
+    }
+
+    return filePaths;
+  } catch (e) {
+    debugPrint('Error during unzip: $e');
+    LectureLoadingService.instance.setError();
     return null;
   }
-
-  return filePaths;
 }
 
 /// Concatenate multiple OPUS audio files into a single continuous OPUS audio file.

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -695,18 +695,12 @@ Future<void> onProgress(
     loadingService.startLoading(lectureTitle, audioCount);
   }
 
-  final currentProgress = loadingService.getProgress();
-  if (currentProgress >= 1.0) {
-    // Completed
-    loadingService.completeLoading();
-  } else {
-    // In progress
-    loadingService.updateProgress(progress, order, message);
-  }
+  // 진행도 갱신 (완료 위젯 노출은 마지막 단계에서 처리)
+  loadingService.updateProgress(progress, order, message);
 
   final updatedProgress = loadingService.getProgress();
   final pct = (updatedProgress * 100).round();
-  final isDone = updatedProgress >= 1.0;
+  final isDone = loadingService.isCompleted;
 
   // Always show notification during progress to keep background task alive
   // Only skip notification if completed and app is in foreground

--- a/frontend/lib/shared/widgets.dart
+++ b/frontend/lib/shared/widgets.dart
@@ -205,6 +205,7 @@ class _ExpandedLoadingOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext widgetContext) {
     final isCompleted = service.progress >= 1.0;
+    final hasError = service.hasError;
 
     return Align(
       alignment: Alignment.bottomCenter,
@@ -225,7 +226,13 @@ class _ExpandedLoadingOverlay extends StatelessWidget {
               duration: const Duration(milliseconds: 250),
               switchInCurve: Curves.easeOutCubic,
               switchOutCurve: Curves.easeInCubic,
-              child: isCompleted
+              child: hasError
+                  ? _ErrorView(
+                      key: const ValueKey('error'),
+                      errorTitle: service.errorTitle,
+                      errorMessage: service.errorMessage,
+                    )
+                  : isCompleted
                   ? _CompletedView(
                       key: const ValueKey('completed'),
                       context: context,
@@ -618,6 +625,84 @@ class _CompletedView extends StatelessWidget {
                     ),
                   ),
                 ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 에러 화면
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    super.key,
+    required this.errorTitle,
+    required this.errorMessage,
+  });
+
+  final String errorTitle;
+  final String errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final service = LectureLoadingService.instance;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      constraints: const BoxConstraints(minHeight: 120),
+      decoration: const BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage('assets/images/loading_background.png'),
+          fit: BoxFit.cover,
+          opacity: 0.15,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _CharacterBlock(),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        errorTitle,
+                        style: textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w800,
+                          color: const Color(0xFFFF6B6B),
+                          letterSpacing: -0.2,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    InkWell(
+                      customBorder: const CircleBorder(),
+                      onTap: service.hideLoading,
+                      child: const Padding(
+                        padding: EdgeInsets.fromLTRB(4, 4, 4, 0),
+                        child: Icon(Icons.close, color: Colors.grey, size: 22),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  errorMessage,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: Colors.grey.shade300,
+                  ),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ],
             ),
           ),

--- a/frontend/lib/shared/widgets.dart
+++ b/frontend/lib/shared/widgets.dart
@@ -611,7 +611,7 @@ class _CompletedView extends StatelessWidget {
                       }
                     },
                     icon: const Icon(Icons.play_circle_outline, size: 20),
-                    label: Text(isKorean ? '생성된 강의 바로가기' : 'Go to Lecture'),
+                    label: Text(isKorean ? '강의 바로가기' : 'Go to Lecture'),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFFF7FAB0),
                       foregroundColor: Colors.black87,

--- a/frontend/lib/shared/widgets.dart
+++ b/frontend/lib/shared/widgets.dart
@@ -204,7 +204,7 @@ class _ExpandedLoadingOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext widgetContext) {
-    final isCompleted = service.progress >= 1.0;
+    final isCompleted = service.isCompleted;
     final hasError = service.hasError;
 
     return Align(

--- a/frontend/test/features/edit/lecture_fetch_test.dart
+++ b/frontend/test/features/edit/lecture_fetch_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:flutter/widgets.dart';
+import 'package:re_view/core/lecture_loading_service.dart';
 import 'package:re_view/features/edit/fetch_lecture.dart';
 import 'package:re_view/features/edit/lecture_form_screen.dart';
 import 'package:syncfusion_flutter_pdf/pdf.dart';
@@ -155,38 +156,39 @@ void main() {
       }
 
       // Act: call with injected client + endpointOverride so we don’t depend on host/port
-      await expectLater(
-        () async => requestLecture(
-          slide.path,
-          audioEntry,
-          'My Lecture',
-          0,
-          1,
-          '127.0.0.1',
-          '8080',
-          onProgress,
-          endpointOverride: Uri.parse(
-            'http://local.test/api/synchronize/stream',
-          ),
-        ),
-        throwsA(anything),
+      final service = LectureLoadingService.instance;
+
+      final resultSingle = await requestLecture(
+        slide.path,
+        audioEntry,
+        'My Lecture',
+        0,
+        1,
+        '127.0.0.1',
+        '8080',
+        onProgress,
+        endpointOverride: Uri.parse('http://local.test/api/synchronize/stream'),
       );
-      await expectLater(
-        () async => requestLecture(
-          slide.path,
-          audioEntry,
-          'My Lecture',
-          0,
-          2,
-          '127.0.0.1',
-          '8080',
-          onProgress,
-          endpointOverride: Uri.parse(
-            'http://local.test/api/synchronize/stream',
-          ),
-        ),
-        throwsA(anything),
+      expect(resultSingle, isNull);
+      expect(service.hasError, isTrue);
+      service.hideLoading();
+
+      final resultMulti = await requestLecture(
+        slide.path,
+        audioEntry,
+        'My Lecture',
+        0,
+        2,
+        '127.0.0.1',
+        '8080',
+        onProgress,
+        endpointOverride: Uri.parse('http://local.test/api/synchronize/stream'),
       );
+      expect(resultMulti, isNull);
+      expect(service.hasError, isTrue);
+      service.hideLoading();
+
+      expect(progressEvents, isEmpty);
 
       try {
         File(


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

Update loading widget to 1) show error widget when aborted, 2) show complete widget when frontend logic is finished as well

---

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Implemented error widget (when server doesn't respond for 30 secs or more, or whatnot OSError etc occurs)
- Synced loading-complete widget appearance time with frontend logic finish (before: showed loading-complete widget when progress from the server reaches 1.0 -> after: waits for lecture id to be created within Hive logic in frontend) 
- Synced '생성된 강의 바로가기' button appearance timing with loading-complete widget.
- Updated unit tests to test new 'error state' while loading

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [x] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @Whitemoons 
- @del2090 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
