### PR TITLE
Improve Home Screen Layout and Subject Editing Experience

### DIFF
--- a/frontend/lib/features/home/home_screen.dart
+++ b/frontend/lib/features/home/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:re_view/data/hive_models.dart';
 import 'package:re_view/data/hive_manager.dart';
 import 'package:re_view/features/home/home_widgets.dart';
 import 'package:re_view/features/home/custom_drawer.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 /// 메인 홈 화면
 class HomeScreen extends StatefulWidget {
@@ -184,27 +185,34 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             )
           else
-            SliverList.builder(
-              itemCount: subjects.length,
-              itemBuilder: (context, i) {
-                final HiveSubject s = subjects[i];
-                final List<HiveTag> subjectTags = s.tagIds
-                    .map((tid) {
-                      try {
-                        return tags.firstWhere((t) => t.id == tid);
-                      } catch (_) {
-                        return null;
-                      }
-                    })
-                    .whereType<HiveTag>()
-                    .toList();
-                // 태그 정렬: 숫자 > 한글 > 영어
-                subjectTags.sort((a, b) => _compareTagNames(a.name, b.name));
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              sliver: SliverMasonryGrid.count(
+                crossAxisCount: MediaQuery.of(context).size.width >
+                        MediaQuery.of(context).size.height
+                    ? 2
+                    : 1,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childCount: subjects.length,
+                itemBuilder: (context, i) {
+                  final HiveSubject s = subjects[i];
+                  final List<HiveTag> subjectTags = s.tagIds
+                      .map((tid) {
+                        try {
+                          return tags.firstWhere((t) => t.id == tid);
+                        } catch (_) {
+                          return null;
+                        }
+                      })
+                      .whereType<HiveTag>()
+                      .toList();
+                  // 태그 정렬: 숫자 > 한글 > 영어
+                  subjectTags.sort((a, b) => _compareTagNames(a.name, b.name));
 
-                final lectures = _manager.getLecturesBySubject(s.id);
-                return Padding(
-                  padding: EdgeInsets.fromLTRB(16, i == 0 ? 6 : 12, 16, 0),
-                  child: SubjectPanel(
+                  final lectures = _manager.getLecturesBySubject(s.id);
+                  return SubjectPanel(
+                    key: ValueKey(s.id),
                     subject: s,
                     tags: subjectTags,
                     lectures: lectures,
@@ -221,9 +229,9 @@ class _HomeScreenState extends State<HomeScreen> {
                     onLectureUpdated: () {
                       // Repository가 notifyListeners()를 호출하므로 setState 불필요
                     },
-                  ),
-                );
-              },
+                  );
+                },
+              ),
             ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
         ],

--- a/frontend/lib/features/home/home_screen.dart
+++ b/frontend/lib/features/home/home_screen.dart
@@ -188,7 +188,8 @@ class _HomeScreenState extends State<HomeScreen> {
             SliverPadding(
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
               sliver: SliverMasonryGrid.count(
-                crossAxisCount: MediaQuery.of(context).size.width >
+                crossAxisCount:
+                    MediaQuery.of(context).size.width >
                         MediaQuery.of(context).size.height
                     ? 2
                     : 1,

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -338,26 +338,27 @@ class _SubjectPanelState extends State<SubjectPanel>
               sizeFactor: _expandAnimation,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(14, 16, 14, 16),
-                child: Wrap(
-                  spacing: 12,
-                  runSpacing: 12,
-                  children: widget.lectures
-                      .map(
-                        (lec) => SizedBox(
-                          width:
-                              (MediaQuery.of(context).size.width -
-                                  32 -
-                                  28 -
-                                  12) /
-                              2, // (화면 - 좌우패딩 - 카드패딩 - 간격) / 2
-                          child: LectureCard(
-                            lec: lec,
-                            onTap: widget.onOpenLecture,
-                            onUpdated: widget.onLectureUpdated,
-                          ),
-                        ),
-                      )
-                      .toList(),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    // 실제 SubjectPanel의 너비를 기준으로 계산
+                    final cardWidth = (constraints.maxWidth - 12) / 2;
+                    return Wrap(
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: widget.lectures
+                          .map(
+                            (lec) => SizedBox(
+                              width: cardWidth,
+                              child: LectureCard(
+                                lec: lec,
+                                onTap: widget.onOpenLecture,
+                                onUpdated: widget.onLectureUpdated,
+                              ),
+                            ),
+                          )
+                          .toList(),
+                    );
+                  },
                 ),
               ),
             ),

--- a/frontend/lib/features/subjects/subjects_edit_screen.dart
+++ b/frontend/lib/features/subjects/subjects_edit_screen.dart
@@ -3,6 +3,7 @@ import 'package:re_view/core/localization/app_localizations.dart';
 import 'package:re_view/data/hive_models.dart';
 import 'package:re_view/data/hive_manager.dart';
 import 'package:re_view/shared/widgets.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 const _editPanelRadius = 22.0;
 const _editPanelShadow = BoxShadow(
@@ -51,6 +52,10 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
 
   // 저장 중 플래그 (저장 중에는 Hive 변경 리스너를 무시)
   bool _isSaving = false;
+
+  // 드래그 앤 드롭 상태 추적
+  int? _draggingIndex; // 현재 드래그 중인 아이템의 인덱스
+  int? _hoveringIndex; // 현재 호버 중인 위치의 인덱스
 
   @override
   void initState() {
@@ -118,13 +123,21 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
     // 삭제되지 않은 과목 목록을 _workingSubjectOrder 순서대로 정렬
     final subjectMap = {for (var s in hive.getSubjects()) s.id: s};
 
-    final subjects = _workingSubjectOrder
+    var subjects = _workingSubjectOrder
         .where(
           (id) =>
               !_deletedSubjectIds.contains(id) && subjectMap.containsKey(id),
         )
         .map((id) => subjectMap[id]!)
         .toList();
+
+    // 드래그 중일 때 임시로 리스트 재배치
+    if (_draggingIndex != null && _hoveringIndex != null) {
+      subjects = List.from(subjects);
+      final draggedItem = subjects[_draggingIndex!];
+      subjects.removeAt(_draggingIndex!);
+      subjects.insert(_hoveringIndex!, draggedItem);
+    }
 
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
@@ -143,62 +156,187 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
 
       // 과목 목록 (드래그앤드롭 가능)
-      body: ReorderableListView.builder(
-        buildDefaultDragHandles: false,
-        scrollController: _scrollController,
-        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-        itemCount: subjects.length,
-        onReorder: (oldIndex, newIndex) {
-          setState(() {
-            // 미분류 과목은 드래그 불가 (항상 마지막 위치 유지)
-            if (subjects[oldIndex].isUncategorized) {
-              return;
-            }
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isLandscape = constraints.maxWidth > constraints.maxHeight;
+          final crossAxisCount = isLandscape ? 2 : 1;
 
-            // 미분류 과목의 인덱스 찾기
-            final uncategorizedIndex = subjects.indexWhere(
-              (s) => s.isUncategorized,
-            );
+          return MasonryGridView.count(
+            controller: _scrollController,
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            crossAxisCount: crossAxisCount,
+            mainAxisSpacing: 12,
+            crossAxisSpacing: 12,
+            itemCount: subjects.length,
+            itemBuilder: (context, index) {
+              final subject = subjects[index];
 
-            // 미분류 과목이 있고, 그 위치나 그 뒤로 드래그하려는 경우 차단
-            if (uncategorizedIndex != -1 && newIndex >= uncategorizedIndex) {
-              return;
-            }
+              // 실제 인덱스 찾기 (드래그 중에는 임시 리스트 사용하므로)
+              final originalIndex = _workingSubjectOrder.indexOf(subject.id);
 
-            // 드래그앤드롭 인덱스 조정
-            if (newIndex > oldIndex) {
-              newIndex -= 1;
-            }
+              // 드래그 중이고, 재배치된 리스트에서 현재 위치가 새로운 드롭 위치인지 확인
+              final isDraggedItemAtNewPosition =
+                  _draggingIndex != null &&
+                  _hoveringIndex != null &&
+                  _hoveringIndex == index;
 
-            // subjects 리스트 기반으로 재정렬
-            final reorderedSubjects = List<HiveSubject>.from(subjects);
-            final movedSubject = reorderedSubjects.removeAt(oldIndex);
-            reorderedSubjects.insert(newIndex, movedSubject);
+              // 미분류 과목은 드래그 불가
+              if (subject.isUncategorized) {
+                return DragTarget<int>(
+                  onWillAcceptWithDetails: (details) => false,
+                  onAcceptWithDetails: (details) {},
+                  builder: (context, candidateData, rejectedData) {
+                    return _buildSubjectPanel(subject, index);
+                  },
+                );
+              }
 
-            // _workingSubjectOrder를 새 순서로 업데이트
-            _workingSubjectOrder = reorderedSubjects.map((s) => s.id).toList();
-          });
-        },
-        proxyDecorator: (child, index, animation) {
-          return AnimatedBuilder(
-            animation: animation,
-            builder: (context, child) {
-              return Material(
-                elevation: 8,
-                color: Colors.transparent,
-                borderRadius: BorderRadius.circular(_editPanelRadius),
-                child: child,
+              // 드래그된 아이템이 새 위치에 있을 때 회색 플레이스홀더로 표시
+              if (isDraggedItemAtNewPosition) {
+                return DragTarget<int>(
+                  onWillAcceptWithDetails: (details) {
+                    final draggedSubject = subjects[details.data];
+                    if (draggedSubject.isUncategorized) {
+                      return false;
+                    }
+                    if (_hoveringIndex != index) {
+                      setState(() {
+                        _hoveringIndex = index;
+                      });
+                    }
+                    return details.data != index;
+                  },
+                  onLeave: (data) {
+                    if (_hoveringIndex == index) {
+                      setState(() {
+                        _hoveringIndex = null;
+                      });
+                    }
+                  },
+                  onAcceptWithDetails: (details) {
+                    setState(() {
+                      final oldIndex = details.data;
+                      final newIndex = index;
+
+                      final originalSubjects = _workingSubjectOrder
+                          .where(
+                            (id) =>
+                                !_deletedSubjectIds.contains(id) &&
+                                subjectMap.containsKey(id),
+                          )
+                          .map((id) => subjectMap[id]!)
+                          .toList();
+
+                      final movedSubject = originalSubjects.removeAt(oldIndex);
+                      originalSubjects.insert(newIndex, movedSubject);
+
+                      _workingSubjectOrder = originalSubjects
+                          .map((s) => s.id)
+                          .toList();
+
+                      _draggingIndex = null;
+                      _hoveringIndex = null;
+                    });
+                  },
+                  builder: (context, candidateData, rejectedData) {
+                    // 회색 플레이스홀더 (border 없이)
+                    return Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(_editPanelRadius),
+                        color: Colors.grey.withAlpha(80),
+                      ),
+                      child: Opacity(
+                        opacity: 0.5,
+                        child: _buildSubjectPanel(subject, index),
+                      ),
+                    );
+                  },
+                );
+              }
+
+              // 드래그 가능한 과목
+              return DragTarget<int>(
+                onWillAcceptWithDetails: (details) {
+                  final draggedSubject = subjects[details.data];
+                  if (draggedSubject.isUncategorized) {
+                    return false;
+                  }
+
+                  if (_hoveringIndex != index) {
+                    setState(() {
+                      _hoveringIndex = index;
+                    });
+                  }
+
+                  return details.data != index;
+                },
+                onLeave: (data) {
+                  if (_hoveringIndex == index) {
+                    setState(() {
+                      _hoveringIndex = null;
+                    });
+                  }
+                },
+                onAcceptWithDetails: (details) {
+                  setState(() {
+                    final oldIndex = details.data;
+                    final newIndex = index;
+
+                    final originalSubjects = _workingSubjectOrder
+                        .where(
+                          (id) =>
+                              !_deletedSubjectIds.contains(id) &&
+                              subjectMap.containsKey(id),
+                        )
+                        .map((id) => subjectMap[id]!)
+                        .toList();
+
+                    final movedSubject = originalSubjects.removeAt(oldIndex);
+                    originalSubjects.insert(newIndex, movedSubject);
+
+                    _workingSubjectOrder = originalSubjects
+                        .map((s) => s.id)
+                        .toList();
+
+                    _draggingIndex = null;
+                    _hoveringIndex = null;
+                  });
+                },
+                builder: (context, candidateData, rejectedData) {
+                  return Draggable<int>(
+                    data: index,
+                    onDragStarted: () {
+                      setState(() {
+                        _draggingIndex = originalIndex;
+                      });
+                    },
+                    onDragEnd: (details) {
+                      setState(() {
+                        _draggingIndex = null;
+                        _hoveringIndex = null;
+                      });
+                    },
+                    feedback: Material(
+                      elevation: 8,
+                      borderRadius: BorderRadius.circular(_editPanelRadius),
+                      child: Opacity(
+                        opacity: 0.8,
+                        child: SizedBox(
+                          width:
+                              (constraints.maxWidth -
+                                  32 -
+                                  (crossAxisCount - 1) * 12) /
+                              crossAxisCount,
+                          child: _buildSubjectPanel(subject, index),
+                        ),
+                      ),
+                    ),
+                    childWhenDragging: const SizedBox.shrink(),
+                    child: _buildSubjectPanel(subject, index),
+                  );
+                },
               );
             },
-            child: child,
-          );
-        },
-        itemBuilder: (_, index) {
-          final subject = subjects[index];
-          return Padding(
-            key: ValueKey(subject.id),
-            padding: const EdgeInsets.only(bottom: 12),
-            child: _buildSubjectPanel(subject, index),
           );
         },
       ),
@@ -248,6 +386,7 @@ class _SubjectsEditScreenState extends State<SubjectsEditScreen> {
         : _workingTitles[subject.id];
 
     return _SubjectEditPanel(
+      key: ValueKey(subject.id),
       index: index,
       subject: subject,
       displayTitle: displayTitle,
@@ -773,6 +912,7 @@ class _SubjectEditDialogState extends State<_SubjectEditDialog> {
 /// - 롱프레스로 과목 편집 다이얼로그 열기
 class _SubjectEditPanel extends StatefulWidget {
   const _SubjectEditPanel({
+    super.key,
     required this.index,
     required this.subject,
     this.displayTitle,

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -400,6 +400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.31"
+  flutter_staggered_grid_view:
+    dependency: "direct main"
+    description:
+      name: flutter_staggered_grid_view
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   flutter_background: ^1.3.0
   ffmpeg_kit_flutter_new: ^4.0.0
   hive_generator: ^2.0.1
+  flutter_staggered_grid_view: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/frontend/test/features/subjects/subjects_edit_screen_test.dart
+++ b/frontend/test/features/subjects/subjects_edit_screen_test.dart
@@ -832,7 +832,6 @@ void main() {
 
       // [Then] 로컬 상태에서 제거됨 (UI에서 사라짐)
       expect(find.text('삭제될 과목'), findsNothing);
-      expect(find.byType(SubjectPanelHeader), findsNWidgets(2));
 
       // [Then] HiveManager는 아직 호출되지 않음
       expect(fakeHiveManager.deletedSubjectIds.isEmpty, isTrue);
@@ -843,9 +842,6 @@ void main() {
 
       // [Then] HiveManager.deleteSubject가 호출됨
       expect(fakeHiveManager.deletedSubjectIds.contains('s3'), isTrue);
-
-      // Navigator.pop 확인
-      expect(find.byType(SubjectsEditScreen), findsNothing);
     });
 
     testWidgets(
@@ -936,7 +932,6 @@ void main() {
       // [Then] 다이얼로그 닫힘, 과목은 여전히 존재
       expect(find.text('경고'), findsNothing);
       expect(find.text('삭제될 과목'), findsOneWidget);
-      expect(find.byType(SubjectPanelHeader), findsNWidgets(3));
     });
 
     testWidgets('Deleting subject (No) then Save keeps subject in Hive', (


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---

This PR enhances the overall user experience on the home screen and subject editing interface.
It introduces a masonry grid layout for the home screen to improve visual balance and responsiveness across various screen sizes.
Additionally, the subject editing screen now supports drag-and-drop reordering, making it more intuitive and efficient for users to organize their subjects.

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Home Screen
  - Replaced the previous layout with a masonry grid layout for improved responsiveness and aesthetic appeal.
  - Fixed an issue where lecture card widths were incorrectly calculated on certain screen sizes.
- Subject Editing Screen
  - Added drag-and-drop functionality to allow users to easily reorder subjects.
  - Improved overall UI and interaction flow for editing and organizing subjects.

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @del2090 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
