### PR TITLE
Implement language compartments in lecture generation

### DIFF
--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -244,7 +244,7 @@ Future<String?> requestLecture(
         await Future.delayed(Duration(seconds: 1));
         return null;
       }
-      
+
       debugPrint('SSE issue triggered');
       final client = http.Client();
       if (jobId == null) {
@@ -437,7 +437,7 @@ Future<List<String>?> fetchLecture(
   int order,
   int audioCount,
   String serverAddress,
-  String port, 
+  String port,
   String langCode, {
   http.Client? fakeClient, // for testing
   Uri? endpointOverride, // for testing

--- a/frontend/lib/features/edit/fetch_lecture.dart
+++ b/frontend/lib/features/edit/fetch_lecture.dart
@@ -94,6 +94,7 @@ Future<String?> requestLecture(
   String serverAddress,
   String port,
   Future<void> Function(double, String, String, int, int) onProgress,
+  String langCode,
   bool isRetry, {
   http.Client? fakeClient, // for testing
   Uri? endpointOverride, // for testing
@@ -169,6 +170,8 @@ Future<String?> requestLecture(
         contentType: MediaType('audio', 'm4a'),
       ),
     );
+
+    req.fields['lang'] = langCode;
   }
 
   // Use the injected client to send
@@ -276,6 +279,7 @@ Future<String?> requestLecture(
         serverAddress,
         port,
         onProgress,
+        langCode,
         true,
       );
       return jobId;
@@ -433,8 +437,8 @@ Future<List<String>?> fetchLecture(
   int order,
   int audioCount,
   String serverAddress,
-  String port,
-  Future<void> Function(double, String, String, int, int) onProgress, {
+  String port, 
+  String langCode, {
   http.Client? fakeClient, // for testing
   Uri? endpointOverride, // for testing
   http.Client? clientToClose, // client that can be closed externally
@@ -449,6 +453,7 @@ Future<List<String>?> fetchLecture(
     serverAddress,
     port,
     onProgress,
+    langCode,
     false,
     fakeClient: fakeClient,
     endpointOverride: endpointOverride,

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -282,12 +282,6 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
               value: _selectedLanguage,
               isExpanded: true,
               icon: Icon(Icons.arrow_drop_down, size: 28, color: textColor),
-              hint: Text(
-                l10n.isKorean
-                    ? '강의자의 언어를 선택해주세요.'
-                    : 'Select the spoken language.',
-                style: TextStyle(fontSize: 16, color: textColor),
-              ),
               dropdownColor: cardColor,
               items: (l10n.isKorean ? ['ko', 'en'] : ['en', 'ko'])
                   .map(

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -49,7 +49,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
   String? _selectedSubjectId;
 
   // 선택된 강의 언어
-  late String _selectedLanguage = AppLocalizations.of(context).isKorean ? 'ko' : 'en';
+  late String _selectedLanguage = AppLocalizations.of(context).isKorean
+      ? 'ko'
+      : 'en';
 
   // 업로드된 슬라이드 PDF 파일 경로
   String? _slidePdfPath;
@@ -281,17 +283,23 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
               isExpanded: true,
               icon: Icon(Icons.arrow_drop_down, size: 28, color: textColor),
               hint: Text(
-                l10n.isKorean ? '강의자의 언어를 선택해주세요.' : 'Select the spoken language.',
+                l10n.isKorean
+                    ? '강의자의 언어를 선택해주세요.'
+                    : 'Select the spoken language.',
                 style: TextStyle(fontSize: 16, color: textColor),
               ),
               dropdownColor: cardColor,
               items: (l10n.isKorean ? ['ko', 'en'] : ['en', 'ko'])
-                .map((code) => DropdownMenuItem<String>(
+                  .map(
+                    (code) => DropdownMenuItem<String>(
                       value: code,
-                      child: Text(labelFor(code),
-                          style: TextStyle(fontSize: 16, color: textColor)),
-                    ))
-                .toList(),
+                      child: Text(
+                        labelFor(code),
+                        style: TextStyle(fontSize: 16, color: textColor),
+                      ),
+                    ),
+                  )
+                  .toList(),
               onChanged: (value) {
                 setState(() {
                   _selectedLanguage = value!;
@@ -1067,11 +1075,13 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
       }
       // Disable background execution when cancelled
       if (backgroundEnabled && Platform.isAndroid) {
-        unawaited(Future.delayed(const Duration(seconds: 1), () async {
-          if (FlutterBackground.isBackgroundExecutionEnabled) {
+        unawaited(
+          Future.delayed(const Duration(seconds: 1), () async {
+            if (FlutterBackground.isBackgroundExecutionEnabled) {
               await FlutterBackground.disableBackgroundExecution();
-          }
-        }));
+            }
+          }),
+        );
       }
     });
 

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -48,6 +48,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
   // 선택된 과목 ID (null = 선택 안 함)
   String? _selectedSubjectId;
 
+  // 선택된 강의 언어
+  late String _selectedLanguage = AppLocalizations.of(context).isKorean ? 'ko' : 'en';
+
   // 업로드된 슬라이드 PDF 파일 경로
   String? _slidePdfPath;
 
@@ -114,6 +117,12 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
                 _buildSectionTitle(l10n.isKorean ? '과목 선택' : 'Select Subject'),
                 const SizedBox(height: 8),
                 _buildSubjectDropdown(l10n, subjects),
+                const SizedBox(height: 20),
+
+                // ========== 강의 언어 선택 섹션 ==========
+                _buildSectionTitle(l10n.isKorean ? '강의 언어' : 'Spoken Language'),
+                const SizedBox(height: 8),
+                _buildLanguageDropdown(l10n, subjects),
                 const SizedBox(height: 20),
 
                 // ========== 강의 주차 입력 섹션 ==========
@@ -237,6 +246,55 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
               onChanged: (value) {
                 setState(() {
                   _selectedSubjectId = value;
+                });
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// 언어 선택 드롭다운 위젯
+  Widget _buildLanguageDropdown(AppLocalizations l10n, List<dynamic> subjects) {
+    return Builder(
+      builder: (context) {
+        final isDark = Theme.of(context).brightness == Brightness.dark;
+        final cardColor = Theme.of(context).cardTheme.color ?? Colors.white;
+        final borderColor = isDark
+            ? Colors.grey.shade700
+            : Colors.grey.shade300;
+        final textColor = isDark ? Colors.white : Colors.black87;
+
+        String labelFor(String code) => (code == 'ko' ? '한국어' : 'English');
+
+        return Container(
+          decoration: BoxDecoration(
+            color: cardColor,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: borderColor),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              value: _selectedLanguage,
+              isExpanded: true,
+              icon: Icon(Icons.arrow_drop_down, size: 28, color: textColor),
+              hint: Text(
+                l10n.isKorean ? '강의자의 언어를 선택해주세요.' : 'Select the spoken language.',
+                style: TextStyle(fontSize: 16, color: textColor),
+              ),
+              dropdownColor: cardColor,
+              items: (l10n.isKorean ? ['ko', 'en'] : ['en', 'ko'])
+                .map((code) => DropdownMenuItem<String>(
+                      value: code,
+                      child: Text(labelFor(code),
+                          style: TextStyle(fontSize: 16, color: textColor)),
+                    ))
+                .toList(),
+              onChanged: (value) {
+                setState(() {
+                  _selectedLanguage = value!;
                 });
               },
             ),
@@ -1057,7 +1115,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
               effectiveAudios.length,
               _serverAddress,
               _port,
-              onProgress,
+              _selectedLanguage,
               clientToClose: clients[i - 1],
             ),
           ),

--- a/frontend/test/features/edit/lecture_fetch_test.dart
+++ b/frontend/test/features/edit/lecture_fetch_test.dart
@@ -113,6 +113,7 @@ void main() {
         '127.0.0.1',
         '8080',
         onProgress,
+        'ko',
         false,
         fakeClient: fakeClient,
         endpointOverride: Uri.parse('http://local.test/api/synchronize/stream'),
@@ -168,6 +169,7 @@ void main() {
         '127.0.0.1',
         '8080',
         onProgress,
+        'ko',
         true,
         endpointOverride: Uri.parse('http://local.test/api/synchronize/stream'),
       );
@@ -184,6 +186,7 @@ void main() {
         '127.0.0.1',
         '8080',
         onProgress,
+        'ko',
         true,
         endpointOverride: Uri.parse('http://local.test/api/synchronize/stream'),
       );


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---
This PR implements UI components to select lecture language & applies it into lecture generation request JSON.
## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Added language selection widget (default set to app language) in lecture form screen.
- Supports Korean audio in client side.
- 

---

## ✅ Checklist
- [x] Code compiles without errors
- [ ] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @Whitemoons 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
