### PR TITLE
Optimize storage usage by removing unnecessary filepicker cache files

### DIFF
--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -910,7 +910,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         .where((e) => (e.filePath ?? '').isNotEmpty)
         .toList();
     for (int i = 0; i < effectiveAudios.length; i++) {
-      try { 
+      try {
         final audioFile = File(effectiveAudios[i].filePath!);
         await audioFile.delete();
         await audioFile.parent.delete();

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -232,7 +232,10 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         title: Text(l10n.isKorean ? '강의 생성' : 'Create Lecture'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.pop(context),
+          onPressed: () {
+            _cleanUpFiles();
+            Navigator.pop(context);
+          },
         ),
       ),
       // backgroundColor는 테마의 scaffoldBackgroundColor 사용
@@ -892,6 +895,27 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
     );
   }
 
+  Future<void> _cleanUpFiles() async {
+    if (_slidePdfPath != null) {
+      try {
+        await File(_slidePdfPath!).delete();
+      } catch (_) {
+        // Ignore deletion errors
+      }
+    }
+
+    final effectiveAudios = _audioFiles
+        .where((e) => (e.filePath ?? '').isNotEmpty)
+        .toList();
+    for (int i = 0; i < effectiveAudios.length; i++) {
+      try { 
+        await File(effectiveAudios[i].filePath!).delete();
+      } catch (_) {
+        // Ignore deletion errors
+      }
+    }
+  }
+
   // ========== 강의 생성 메서드 ==========
 
   /// 강의 생성 처리
@@ -1140,6 +1164,7 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         }
       } else {
         for (int i = 0; i < results.length; i++) {
+          await _cleanUpFiles();
           if (results[i] != null) {
             if (langCode == 'en') {
               await File(results[i]![0]).delete();
@@ -1182,6 +1207,15 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         if (originalAudioPath == null ||
             (ttsAudioPath == null && langCode == 'en') ||
             jsonPath == null) {
+          for (int i = 0; i < results.length; i++) {
+            await _cleanUpFiles();
+            if (results[i] != null) {
+              if (langCode == 'en') {
+                await File(results[i]![0]).delete();
+              }
+              await File(results[i]![1]).delete();
+            }
+          }
           _showToast(
             l10n.isKorean ? '강의 생성에 실패했습니다.' : 'Lecture generation failed.',
           );

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -898,7 +898,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
   Future<void> _cleanUpFiles() async {
     if (_slidePdfPath != null) {
       try {
-        await File(_slidePdfPath!).delete();
+        final slideFile = File(_slidePdfPath!);
+        await slideFile.delete();
+        await slideFile.parent.delete();
       } catch (_) {
         // Ignore deletion errors
       }
@@ -909,7 +911,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
         .toList();
     for (int i = 0; i < effectiveAudios.length; i++) {
       try { 
-        await File(effectiveAudios[i].filePath!).delete();
+        final audioFile = File(effectiveAudios[i].filePath!);
+        await audioFile.delete();
+        await audioFile.parent.delete();
       } catch (_) {
         // Ignore deletion errors
       }


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---
This PR implements appropriate removal of unnecessary filepicker cache files.
## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- When the user pops out of the lecture form screen before sending lecture generation request or lecture generation fails, the files relevant to that request is cleared from the filepicker cache.

---

## ✅ Checklist
- [x] Code compiles without errors
- [ ] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @Whitemoons 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
