### PR TITLE
Refined localizations of settings subscreens

### DIFF
--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -52,10 +52,11 @@ class AppLocalizations {
   String get displayMode => isKorean ? '디스플레이 모드' : 'Display Mode';
   String get accessibility => isKorean ? '접근성' : 'Accessibility';
   String get tts => isKorean ? 'TTS 설정' : 'TTS Configurations';
-  String get language => isKorean ? '언어' : 'Language';
+  String get language => isKorean ? '언어 / Language' : 'Language / 언어';
   String get lightMode => isKorean ? '라이트 모드' : 'Light Mode';
   String get darkMode => isKorean ? '다크 모드' : 'Dark Mode';
   String get systemSettings => isKorean ? '시스템 설정' : 'System Settings';
+  String get help => isKorean ? '도움말' : 'Help';
 
   // FAQ
   String get howToFindLecture =>

--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -51,6 +51,7 @@ class AppLocalizations {
   // 설정 화면
   String get displayMode => isKorean ? '디스플레이 모드' : 'Display Mode';
   String get accessibility => isKorean ? '접근성' : 'Accessibility';
+  String get tts => isKorean ? 'TTS 설정' : 'TTS Configurations';
   String get language => isKorean ? '언어' : 'Language';
   String get lightMode => isKorean ? '라이트 모드' : 'Light Mode';
   String get darkMode => isKorean ? '다크 모드' : 'Dark Mode';

--- a/frontend/lib/features/edit/lecture_form_screen.dart
+++ b/frontend/lib/features/edit/lecture_form_screen.dart
@@ -702,7 +702,9 @@ class _LectureFormScreenState extends State<LectureFormScreen> {
                       )
                     : Text(
                         l10n.isKorean ? '생성하기' : 'Create',
-                        style: theme.textTheme.titleMedium,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: Colors.white,
+                        ),
                       ),
               ),
             ),

--- a/frontend/lib/features/settings/help_screen.dart
+++ b/frontend/lib/features/settings/help_screen.dart
@@ -12,7 +12,7 @@ class HelpScreen extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Help')),
+      appBar: AppBar(title: Text(l10n.help)),
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
       body: ListView(
         padding: const EdgeInsets.all(16),
@@ -65,17 +65,7 @@ class HelpScreen extends StatelessWidget {
             answer: l10n.useUnsyncButton,
           ),
           const SizedBox(height: 24),
-          l10n.isKorean
-              ? _InfoCard(
-                  title: '한국어 강의도 지원되나요?',
-                  body:
-                      '  현재 개발 중에 있으며 11월 중으로 만나보실 수 있습니다!\n'
-                      '  기대해주세요 :)',
-                )
-              : _InfoCard(
-                  title: l10n.buyCoffee,
-                  body: '  https://buymeacoffee.com',
-                ),
+          _InfoCard(title: l10n.buyCoffee, body: '  https://buymeacoffee.com'),
         ],
       ),
     );

--- a/frontend/lib/features/settings/language_screen.dart
+++ b/frontend/lib/features/settings/language_screen.dart
@@ -67,7 +67,9 @@ class _LanguageScreenState extends State<LanguageScreen> {
 
     return Scaffold(
       // 상단 앱바 (한영 모두 표시)
-      appBar: AppBar(title: Text(l10n.isKorean ? '언어 / Language' : 'Language / 언어')),
+      appBar: AppBar(
+        title: Text(l10n.isKorean ? '언어 / Language' : 'Language / 언어'),
+      ),
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
 
       // 언어 선택 라디오 버튼 목록
@@ -84,10 +86,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
                 children: <Widget>[
                   RadioListTile<String>(
                     value: 'ko',
-                    title: const Text(
-                      '한국어',
-                      style: TextStyle(fontSize: 18),
-                    ),
+                    title: const Text('한국어', style: TextStyle(fontSize: 18)),
                     contentPadding: const EdgeInsets.symmetric(
                       horizontal: 24,
                       vertical: 8,

--- a/frontend/lib/features/settings/language_screen.dart
+++ b/frontend/lib/features/settings/language_screen.dart
@@ -67,9 +67,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
 
     return Scaffold(
       // 상단 앱바 (한영 모두 표시)
-      appBar: AppBar(
-        title: Text(l10n.isKorean ? '언어 / Language' : 'Language / 언어'),
-      ),
+      appBar: AppBar(title: Text(l10n.language)),
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
 
       // 언어 선택 라디오 버튼 목록

--- a/frontend/lib/features/settings/language_screen.dart
+++ b/frontend/lib/features/settings/language_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:re_view/core/localization/app_localizations.dart';
 import 'package:re_view/data/hive_manager.dart';
 
 /// 언어 설정 화면 (Figma 2-4-4. Language)
@@ -60,12 +61,13 @@ class _LanguageScreenState extends State<LanguageScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final currentLang = _manager.settings.language;
 
     return Scaffold(
       // 상단 앱바 (한영 모두 표시)
-      appBar: AppBar(title: const Text('언어 / Language')),
+      appBar: AppBar(title: Text(l10n.isKorean ? '언어 / Language' : 'Language / 언어')),
       backgroundColor: isDark ? null : const Color(0xFFF5F5F5),
 
       // 언어 선택 라디오 버튼 목록
@@ -83,7 +85,7 @@ class _LanguageScreenState extends State<LanguageScreen> {
                   RadioListTile<String>(
                     value: 'ko',
                     title: const Text(
-                      '한국어 / Korean',
+                      '한국어',
                       style: TextStyle(fontSize: 18),
                     ),
                     contentPadding: const EdgeInsets.symmetric(

--- a/frontend/lib/features/settings/settings_screen.dart
+++ b/frontend/lib/features/settings/settings_screen.dart
@@ -59,7 +59,7 @@ class SettingsScreen extends StatelessWidget {
             ),
 
             // 5. 도움말: 기본 안내 및 튜토리얼
-            _buildNavigationTile(context, 'Help', Routes.settingsHelp),
+            _buildNavigationTile(context, l10n.help, Routes.settingsHelp),
           ],
         ),
       ),

--- a/frontend/lib/features/settings/settings_screen.dart
+++ b/frontend/lib/features/settings/settings_screen.dart
@@ -42,7 +42,7 @@ class SettingsScreen extends StatelessWidget {
             ),
 
             // 2. TTS: 음성 성별, 악센트, 재생 속도 설정
-            _buildNavigationTile(context, 'TTS', Routes.settingsTts),
+            _buildNavigationTile(context, l10n.tts, Routes.settingsTts),
 
             // 3. 접근성: 고대비, 모션 줄이기, 자막 강조
             _buildNavigationTile(

--- a/frontend/lib/features/settings/tts_screen.dart
+++ b/frontend/lib/features/settings/tts_screen.dart
@@ -83,15 +83,11 @@ class _TtsScreenState extends State<TtsScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
-    final isKorean = AppLocalizations.of(context).isKorean;
+    final l10n = AppLocalizations.of(context);
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('TTS'),
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () => Navigator.pop(context),
-        ),
+        title: Text(l10n.tts),
       ),
       backgroundColor: isDark
           ? theme.scaffoldBackgroundColor
@@ -101,12 +97,12 @@ class _TtsScreenState extends State<TtsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _buildSectionTitle(isKorean ? 'TTS 음성 성별' : 'TTS Voice Gender'),
+            _buildSectionTitle(l10n.isKorean ? 'TTS 음성 성별' : 'TTS Voice Gender'),
             const SizedBox(height: 12),
-            _buildGenderButtons(isKorean),
+            _buildGenderButtons(l10n.isKorean),
             const SizedBox(height: 8),
             Text(
-              isKorean
+              l10n.isKorean
                   ? '현재 여성 TTS 음성만 지원됩니다.'
                   : 'Only female TTS voices are currently supported.',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/frontend/lib/features/settings/tts_screen.dart
+++ b/frontend/lib/features/settings/tts_screen.dart
@@ -86,9 +86,7 @@ class _TtsScreenState extends State<TtsScreen> {
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.tts),
-      ),
+      appBar: AppBar(title: Text(l10n.tts)),
       backgroundColor: isDark
           ? theme.scaffoldBackgroundColor
           : const Color(0xFFF5F5F5),
@@ -97,7 +95,9 @@ class _TtsScreenState extends State<TtsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _buildSectionTitle(l10n.isKorean ? 'TTS 음성 성별' : 'TTS Voice Gender'),
+            _buildSectionTitle(
+              l10n.isKorean ? 'TTS 음성 성별' : 'TTS Voice Gender',
+            ),
             const SizedBox(height: 12),
             _buildGenderButtons(l10n.isKorean),
             const SizedBox(height: 8),

--- a/frontend/test/core/localization/app_localizations_test.dart
+++ b/frontend/test/core/localization/app_localizations_test.dart
@@ -147,8 +147,8 @@ void main() {
       });
 
       test('language returns correct translation', () {
-        expect(koreanLocalizations.language, '언어');
-        expect(englishLocalizations.language, 'Language');
+        expect(koreanLocalizations.language, '언어 / Language');
+        expect(englishLocalizations.language, 'Language / 언어');
       });
 
       test('lightMode returns correct translation', () {

--- a/frontend/test/features/player/mocks.mocks.dart
+++ b/frontend/test/features/player/mocks.mocks.dart
@@ -436,6 +436,19 @@ class MockHiveManager extends _i1.Mock implements _i9.HiveManager {
           as _i4.Future<void>);
 
   @override
+  _i4.Future<void> reorderLecture(
+    String? subjectId,
+    int? oldIndex,
+    int? newIndex,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#reorderLecture, [subjectId, oldIndex, newIndex]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
   List<_i2.HiveTag> getTags() =>
       (super.noSuchMethod(
             Invocation.method(#getTags, []),

--- a/frontend/test/features/settings/help_screen_test.dart
+++ b/frontend/test/features/settings/help_screen_test.dart
@@ -27,13 +27,13 @@ void main() {
 
   group('help_screen.dart: Widget Test', () {
     group('1. UI Initial State Verification', () {
-      testWidgets('AppBar title should display "Help"', (tester) async {
+      testWidgets('AppBar title should display "도움말"', (tester) async {
         await pumpHelpScreen(tester);
         await tester.pumpAndSettle();
 
         expect(find.byType(AppBar), findsOneWidget);
         expect(
-          find.descendant(of: find.byType(AppBar), matching: find.text('Help')),
+          find.descendant(of: find.byType(AppBar), matching: find.text('도움말')),
           findsOneWidget,
         );
       });

--- a/frontend/test/features/settings/language_screen_test.dart
+++ b/frontend/test/features/settings/language_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
+import 'package:re_view/core/localization/app_localizations.dart';
 import 'package:re_view/data/hive_models.dart';
 import 'package:re_view/data/hive_manager.dart';
 import 'package:re_view/features/settings/language_screen.dart';
@@ -26,8 +28,19 @@ void main() {
   // 테스트 헬퍼: 화면 펌핑
   Future<void> pumpLanguageScreen(WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(home: LanguageScreen(hiveManager: mockHiveManager)),
+      MaterialApp(
+        localizationsDelegates: [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: LanguageScreen(hiveManager: mockHiveManager),
+      ),
     );
+
+    await tester.pumpAndSettle();
   }
 
   group('language_screen.dart: Widget Test', () {
@@ -45,7 +58,7 @@ void main() {
         // [Then] - 라디오 그룹이 한국어여야 함
         final koRadioGroup = tester.widget<RadioGroup<String>>(
           find.ancestor(
-            of: find.text('한국어 / Korean'),
+            of: find.text('한국어'),
             matching: find.byType(RadioGroup<String>),
           ),
         );
@@ -73,7 +86,7 @@ void main() {
         // [Then]
         final koRadioGroup = tester.widget<RadioGroup<String>>(
           find.ancestor(
-            of: find.text('한국어 / Korean'),
+            of: find.text('한국어'),
             matching: find.byType(RadioGroup<String>),
           ),
         );
@@ -88,21 +101,21 @@ void main() {
         expect(enRadioGroup.groupValue, 'en');
       });
 
-      testWidgets('AppBar title should display "언어 / Language"', (
+      testWidgets('AppBar title should display "Language / 언어"', (
         tester,
       ) async {
+        // [Given]
+        when(mockSettings.language).thenReturn('en');
+
         // [When]
         await pumpLanguageScreen(tester);
 
         // [Then]
-        expect(find.byType(AppBar), findsOneWidget);
-        expect(
-          find.descendant(
-            of: find.byType(AppBar),
-            matching: find.text('언어 / Language'),
-          ),
-          findsOneWidget,
-        );
+        final appBar = tester.widget<AppBar>(find.byType(AppBar));
+        expect(appBar.title, isA<Text>());
+
+        final titleText = appBar.title as Text;
+        expect(titleText.data, 'Language / 언어');
       });
     });
 
@@ -115,7 +128,7 @@ void main() {
         await pumpLanguageScreen(tester);
 
         // [When]
-        await tester.tap(find.text('한국어 / Korean'));
+        await tester.tap(find.text('한국어'));
         await tester.pumpAndSettle();
 
         // [Then]
@@ -183,7 +196,7 @@ void main() {
 
           final initialRadioGroup = tester.widget<RadioGroup<String>>(
             find.ancestor(
-              of: find.text('한국어 / Korean'),
+              of: find.text('한국어'),
               matching: find.byType(RadioGroup<String>),
             ),
           );
@@ -201,7 +214,7 @@ void main() {
           // [Then]
           final updatedRadioGroup = tester.widget<RadioGroup<String>>(
             find.ancestor(
-              of: find.text('한국어 / Korean'),
+              of: find.text('한국어'),
               matching: find.byType(RadioGroup<String>),
             ),
           );

--- a/frontend/test/features/settings/settings_screen_test.dart
+++ b/frontend/test/features/settings/settings_screen_test.dart
@@ -73,8 +73,8 @@ void main() {
           expect(find.text(l10n.displayMode), findsOneWidget);
           expect(find.text(l10n.accessibility), findsOneWidget);
           expect(find.text(l10n.language), findsOneWidget);
-          expect(find.text('TTS'), findsOneWidget);
-          expect(find.text('Help'), findsOneWidget);
+          expect(find.text(l10n.tts), findsOneWidget);
+          expect(find.text(l10n.help), findsOneWidget);
         },
       );
 
@@ -117,7 +117,7 @@ void main() {
       ) async {
         await pumpAndGetL10n(tester);
 
-        await tester.tap(find.text('TTS'));
+        await tester.tap(find.text('TTS 설정'));
         await tester.pumpAndSettle();
 
         verify(
@@ -185,7 +185,7 @@ void main() {
       ) async {
         await pumpAndGetL10n(tester);
 
-        await tester.tap(find.text('Help'));
+        await tester.tap(find.text('도움말'));
         await tester.pumpAndSettle();
 
         verify(

--- a/frontend/test/features/settings/tts_screen_test.dart
+++ b/frontend/test/features/settings/tts_screen_test.dart
@@ -47,8 +47,7 @@ void main() {
       ),
     );
 
-    await tester.pump(); // 로딩 시작
-    await tester.pump(const Duration(seconds: 1)); // 로딩 완료 대기
+    await tester.pumpAndSettle();
   }
 
   group('tts_screen.dart: Widget Test', () {
@@ -58,21 +57,13 @@ void main() {
         expect(find.byType(Scaffold), findsOneWidget);
       });
 
-      testWidgets('AppBar title should be "TTS" with close button', (
-        tester,
-      ) async {
+      testWidgets('AppBar title should be "TTS 설정"', (tester) async {
         await pumpTtsScreen(tester);
-        expect(
-          find.descendant(of: find.byType(AppBar), matching: find.text('TTS')),
-          findsOneWidget,
-        );
-        expect(
-          find.descendant(
-            of: find.byType(AppBar),
-            matching: find.byIcon(Icons.close),
-          ),
-          findsOneWidget,
-        );
+        final appBar = tester.widget<AppBar>(find.byType(AppBar));
+        expect(appBar.title, isA<Text>());
+
+        final titleText = appBar.title as Text;
+        expect(titleText.data, 'TTS 설정');
       });
 
       testWidgets('Korean labels should be displayed in Korean locale', (


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---
This PR implements miscellaneous localization refinements for settings screen and its subscreens.
## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Miscellaneous localization refinements for settings screen and its subscreens.
- Changed the color of 'Create' text in lecture form screen to white.
- 

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @Whitemoons 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
