### PR TITLE
Implement side-snapping function to circular loading widget & show lecture created date

### DIFF
--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -183,6 +183,7 @@ class AppLocalizations {
   String get week => isKorean ? '주차' : 'Week';
   String get lectureTitle => isKorean ? '강의 제목' : 'Lecture Title';
   String get lectureLength => isKorean ? '강의 길이' : 'Lecture Length';
+  String get createdAt => isKorean ? '생성일' : 'Created';
   String get deleteLecture => isKorean ? '강의 삭제' : 'Delete Lecture';
 
   // 검색 화면

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -792,7 +792,9 @@ class _LectureDetailDialogState extends State<_LectureDetailDialog> {
   }
 
   String _formatDate(DateTime? dateTime, bool isKorean) {
-    if (dateTime == null) return isKorean ? '알 수 없음' : 'Unknown';
+    if (dateTime == null) {
+      return isKorean ? '알 수 없음' : 'Unknown';
+    }
 
     // 절대 날짜 포맷만 표시
     final year = dateTime.year;

--- a/frontend/lib/features/home/home_widgets.dart
+++ b/frontend/lib/features/home/home_widgets.dart
@@ -791,6 +791,37 @@ class _LectureDetailDialogState extends State<_LectureDetailDialog> {
     return '$minutes:${secs.toString().padLeft(2, '0')}';
   }
 
+  String _formatDate(DateTime? dateTime, bool isKorean) {
+    if (dateTime == null) return isKorean ? '알 수 없음' : 'Unknown';
+
+    // 절대 날짜 포맷만 표시
+    final year = dateTime.year;
+    final month = dateTime.month;
+    final day = dateTime.day;
+
+    return isKorean
+        ? '$year년 $month월 $day일'
+        : '${_monthName(month)} $day, $year';
+  }
+
+  String _monthName(int month) {
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return months[month - 1];
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context);
@@ -921,6 +952,34 @@ class _LectureDetailDialogState extends State<_LectureDetailDialog> {
                 Text(
                   _formatDuration(widget.lecture.duration),
                   style: theme.textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          // 생성일 정보
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.calendar_today, size: 20),
+                    const SizedBox(width: 8),
+                    Text(l10n.createdAt, style: theme.textTheme.titleSmall),
+                  ],
+                ),
+                Expanded(
+                  child: Text(
+                    _formatDate(widget.lecture.createdAt, l10n.isKorean),
+                    style: theme.textTheme.bodyMedium,
+                    textAlign: TextAlign.right,
+                  ),
                 ),
               ],
             ),

--- a/frontend/lib/shared/widgets.dart
+++ b/frontend/lib/shared/widgets.dart
@@ -275,6 +275,7 @@ class CollapsedBubbleOverlay extends StatefulWidget {
 class _CollapsedBubbleOverlayState extends State<CollapsedBubbleOverlay> {
   late double _dragX;
   late double _dragY;
+  bool _isDragging = false;
 
   @override
   void initState() {
@@ -292,7 +293,11 @@ class _CollapsedBubbleOverlayState extends State<CollapsedBubbleOverlay> {
 
     return Stack(
       children: [
-        Positioned(
+        AnimatedPositioned(
+          duration: _isDragging
+              ? Duration.zero
+              : const Duration(milliseconds: 300),
+          curve: Curves.easeOutBack,
           left: _dragX,
           bottom: _dragY,
           child: SafeArea(
@@ -300,14 +305,16 @@ class _CollapsedBubbleOverlayState extends State<CollapsedBubbleOverlay> {
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
               onPanStart: (details) {
-                // Prevent tap from triggering during drag
+                setState(() {
+                  _isDragging = true;
+                });
               },
               onPanUpdate: (details) {
                 setState(() {
-                  // Update position during drag
+                  // Update position during drag (allow free movement temporarily)
                   _dragX = (_dragX + details.delta.dx).clamp(
-                    0.0,
-                    screenSize.width - bubbleSize - safeArea.right,
+                    -(bubbleSize * 0.1),
+                    screenSize.width - bubbleSize * 0.9 - safeArea.right,
                   );
                   _dragY = (_dragY - details.delta.dy).clamp(
                     0.0,
@@ -316,6 +323,22 @@ class _CollapsedBubbleOverlayState extends State<CollapsedBubbleOverlay> {
                 });
               },
               onPanEnd: (details) {
+                // Snap to left or right side with 10% clipping
+                final screenCenter = screenSize.width / 2;
+                final isOnLeftSide = _dragX < screenCenter - bubbleSize / 2;
+
+                setState(() {
+                  _isDragging = false;
+                  if (isOnLeftSide) {
+                    // Snap to left with 10% clipped
+                    _dragX = -(bubbleSize * 0.1);
+                  } else {
+                    // Snap to right with 10% clipped
+                    _dragX =
+                        screenSize.width - bubbleSize * 0.9 - safeArea.right;
+                  }
+                });
+
                 // Save final position when drag ends
                 widget.service.updateBubblePosition(_dragX, _dragY);
               },

--- a/frontend/test/shared/widgets_test.dart
+++ b/frontend/test/shared/widgets_test.dart
@@ -508,7 +508,7 @@ void main() {
     });
 
     testWidgets(
-      'drag updates visual position and calls updateBubblePosition on pan end',
+      'drag left snaps to left side with 10% clipping',
       (tester) async {
         await tester.pumpWidget(
           MaterialApp(
@@ -519,13 +519,50 @@ void main() {
         final gestureFinder = find.byType(GestureDetector);
         expect(gestureFinder, findsOneWidget);
 
+        // Drag to the right (but not enough to reach right side)
         await tester.drag(gestureFinder, const Offset(40, -20));
         await tester.pumpAndSettle();
 
         verify(mockService.updateBubblePosition(any, any)).called(1);
 
-        final positioned = tester.widget<Positioned>(find.byType(Positioned));
-        expect(positioned.left, greaterThan(0.0));
+        // After drag ends, bubble should snap to left side
+        // Initial position (32, 48) + drag (40, -20) = (72, 68)
+        // Screen center is 400, so 72 < 356 (400 - bubbleSize/2)
+        // Therefore it snaps to the left side with 10% clipping
+        final positioned =
+            tester.widget<AnimatedPositioned>(find.byType(AnimatedPositioned));
+        const bubbleSize = 88.0;
+        expect(positioned.left, equals(-(bubbleSize * 0.1)));
+        expect(positioned.bottom, greaterThan(0.0));
+      },
+    );
+
+    testWidgets(
+      'drag right snaps to right side with 10% clipping',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: CollapsedBubbleOverlay(service: mockService)),
+          ),
+        );
+
+        final gestureFinder = find.byType(GestureDetector);
+        expect(gestureFinder, findsOneWidget);
+
+        // Drag far to the right to reach right side
+        await tester.drag(gestureFinder, const Offset(500, -20));
+        await tester.pumpAndSettle();
+
+        verify(mockService.updateBubblePosition(any, any)).called(1);
+
+        // After drag ends, bubble should snap to right side
+        // Screen width is 800, bubbleSize is 88
+        // Right position: 800 - 88 * 0.9 - 0 (safeArea.right) = 720.8
+        final positioned =
+            tester.widget<AnimatedPositioned>(find.byType(AnimatedPositioned));
+        const bubbleSize = 88.0;
+        const screenWidth = 800.0; // Default test screen width
+        expect(positioned.left, equals(screenWidth - bubbleSize * 0.9));
         expect(positioned.bottom, greaterThan(0.0));
       },
     );

--- a/frontend/test/shared/widgets_test.dart
+++ b/frontend/test/shared/widgets_test.dart
@@ -507,65 +507,65 @@ void main() {
       verify(mockService.expandFromBubble()).called(1);
     });
 
-    testWidgets(
-      'drag left snaps to left side with 10% clipping',
-      (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(body: CollapsedBubbleOverlay(service: mockService)),
-          ),
-        );
+    testWidgets('drag left snaps to left side with 10% clipping', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: CollapsedBubbleOverlay(service: mockService)),
+        ),
+      );
 
-        final gestureFinder = find.byType(GestureDetector);
-        expect(gestureFinder, findsOneWidget);
+      final gestureFinder = find.byType(GestureDetector);
+      expect(gestureFinder, findsOneWidget);
 
-        // Drag to the right (but not enough to reach right side)
-        await tester.drag(gestureFinder, const Offset(40, -20));
-        await tester.pumpAndSettle();
+      // Drag to the right (but not enough to reach right side)
+      await tester.drag(gestureFinder, const Offset(40, -20));
+      await tester.pumpAndSettle();
 
-        verify(mockService.updateBubblePosition(any, any)).called(1);
+      verify(mockService.updateBubblePosition(any, any)).called(1);
 
-        // After drag ends, bubble should snap to left side
-        // Initial position (32, 48) + drag (40, -20) = (72, 68)
-        // Screen center is 400, so 72 < 356 (400 - bubbleSize/2)
-        // Therefore it snaps to the left side with 10% clipping
-        final positioned =
-            tester.widget<AnimatedPositioned>(find.byType(AnimatedPositioned));
-        const bubbleSize = 88.0;
-        expect(positioned.left, equals(-(bubbleSize * 0.1)));
-        expect(positioned.bottom, greaterThan(0.0));
-      },
-    );
+      // After drag ends, bubble should snap to left side
+      // Initial position (32, 48) + drag (40, -20) = (72, 68)
+      // Screen center is 400, so 72 < 356 (400 - bubbleSize/2)
+      // Therefore it snaps to the left side with 10% clipping
+      final positioned = tester.widget<AnimatedPositioned>(
+        find.byType(AnimatedPositioned),
+      );
+      const bubbleSize = 88.0;
+      expect(positioned.left, equals(-(bubbleSize * 0.1)));
+      expect(positioned.bottom, greaterThan(0.0));
+    });
 
-    testWidgets(
-      'drag right snaps to right side with 10% clipping',
-      (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(body: CollapsedBubbleOverlay(service: mockService)),
-          ),
-        );
+    testWidgets('drag right snaps to right side with 10% clipping', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: CollapsedBubbleOverlay(service: mockService)),
+        ),
+      );
 
-        final gestureFinder = find.byType(GestureDetector);
-        expect(gestureFinder, findsOneWidget);
+      final gestureFinder = find.byType(GestureDetector);
+      expect(gestureFinder, findsOneWidget);
 
-        // Drag far to the right to reach right side
-        await tester.drag(gestureFinder, const Offset(500, -20));
-        await tester.pumpAndSettle();
+      // Drag far to the right to reach right side
+      await tester.drag(gestureFinder, const Offset(500, -20));
+      await tester.pumpAndSettle();
 
-        verify(mockService.updateBubblePosition(any, any)).called(1);
+      verify(mockService.updateBubblePosition(any, any)).called(1);
 
-        // After drag ends, bubble should snap to right side
-        // Screen width is 800, bubbleSize is 88
-        // Right position: 800 - 88 * 0.9 - 0 (safeArea.right) = 720.8
-        final positioned =
-            tester.widget<AnimatedPositioned>(find.byType(AnimatedPositioned));
-        const bubbleSize = 88.0;
-        const screenWidth = 800.0; // Default test screen width
-        expect(positioned.left, equals(screenWidth - bubbleSize * 0.9));
-        expect(positioned.bottom, greaterThan(0.0));
-      },
-    );
+      // After drag ends, bubble should snap to right side
+      // Screen width is 800, bubbleSize is 88
+      // Right position: 800 - 88 * 0.9 - 0 (safeArea.right) = 720.8
+      final positioned = tester.widget<AnimatedPositioned>(
+        find.byType(AnimatedPositioned),
+      );
+      const bubbleSize = 88.0;
+      const screenWidth = 800.0; // Default test screen width
+      expect(positioned.left, equals(screenWidth - bubbleSize * 0.9));
+      expect(positioned.bottom, greaterThan(0.0));
+    });
   });
 
   group('ExpandedLoadingOverlay and inner views', () {


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->
Implement side-snapping function to circular loading widget & show lecture created date
---

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- identical to PR title
- Edited one test about loading ui behavior to fit changes

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [x] Added/updated tests
- [x] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @del2090 
- @Whitemoons 

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
