### PR TITLE
Slide Matching Algorithm Improvements

### DIFF
--- a/backend/inference_models/lecture_pipeline.py
+++ b/backend/inference_models/lecture_pipeline.py
@@ -83,6 +83,7 @@ class LecturePipeline:
         use_context_similarity: bool = True,
         context_weight: float = 0.05,
         context_update_rate: float = 0.25,
+        min_sentence_length: int = 0,
 
         # Translation settings
         translation_model: str = "tencent/Hunyuan-MT-7B-fp8",
@@ -121,6 +122,7 @@ class LecturePipeline:
             use_context_similarity: Enable context-aware scoring via EMA
             context_weight: weight for context similarity contribution
             context_update_rate: Update rate for EMA
+            min_sentence_length: Minimum sentence length (words) to use similarity score
             translation_model: Translation model name
             translation_tensor_parallel_size: Number of GPUs for translation tensor parallelism
             enable_translation: Enable translation (direction determined per request)
@@ -164,7 +166,8 @@ class LecturePipeline:
             confidence_weight = confidence_weight,
             use_context_similarity = use_context_similarity,
             context_weight = context_weight,
-            context_update_rate = context_update_rate
+            context_update_rate = context_update_rate,
+            min_sentence_length = min_sentence_length
         )
 
         # Initialize translation processor if enabled
@@ -698,6 +701,7 @@ if __name__ == "__main__":
         use_context_similarity = True,
         context_weight = 0.05,
         context_update_rate = 0.25,
+        min_sentence_length = 2,
 
         # TTS settings
         tts_voice = 'af_heart',

--- a/backend/inference_models/lecture_pipeline.py
+++ b/backend/inference_models/lecture_pipeline.py
@@ -66,24 +66,24 @@ class LecturePipeline:
         # ASR settings
         asr_model: str = "turbo",
         asr_chunk_seconds: int = 300,
-        asr_batch_size: int = 4,
+        asr_batch_size: int = 3,
 
         # Slide matching settings
         matching_model: str = 'nvidia/llama-nemoretriever-colembed-3b-v1',
         matching_batch_size: int = 4,
         use_image_batching: bool = False, # for stability
         image_batch_size: int = 4,
-        jump_penalty: float = 0.2,
-        backward_weight: float = 2.0,
+        jump_penalty: float = 1.5,
+        backward_weight: float = 1.85,
         use_exponential_scaling: bool = True,
-        exponential_scale: float = 2.8,
+        exponential_scale: float = 2.785,
         use_confidence_boost: bool = True,
-        confidence_threshold: float = 0.925,
-        confidence_weight: float = 2.25,
+        confidence_threshold: float = 0.913,
+        confidence_weight: float = 2.18,
         use_context_similarity: bool = True,
-        context_weight: float = 0.05,
-        context_update_rate: float = 0.25,
-        min_sentence_length: int = 0,
+        context_weight: float = 0.04,
+        context_update_rate: float = 0.24,
+        min_sentence_length: int = 2,
 
         # Translation settings
         translation_model: str = "tencent/Hunyuan-MT-7B-fp8",

--- a/backend/inference_models/slide_matching_processor.py
+++ b/backend/inference_models/slide_matching_processor.py
@@ -36,17 +36,17 @@ class SlideMatchingProcessor:
         batch_size: int = 4,
         use_image_batching: bool = True,
         image_batch_size: int = 4,
-        jump_penalty: float = 0.2,
-        backward_weight: float = 2.0,
+        jump_penalty: float = 1.5,
+        backward_weight: float = 1.85,
         use_exponential_scaling: bool = True,
-        exponential_scale: float = 2.8,
+        exponential_scale: float = 2.785,
         use_confidence_boost: bool = True,
-        confidence_threshold: float = 0.925,
-        confidence_weight: float = 2.25,
+        confidence_threshold: float = 0.913,
+        confidence_weight: float = 2.18,
         use_context_similarity: bool = True,
-        context_weight: float = 0.05,
-        context_update_rate: float = 0.25,
-        min_sentence_length: int = 0
+        context_weight: float = 0.04,
+        context_update_rate: float = 0.24,
+        min_sentence_length: int = 2
     ):
         """
         Initialize slide matching processor.

--- a/backend/inference_models/slide_matching_processor.py
+++ b/backend/inference_models/slide_matching_processor.py
@@ -45,7 +45,8 @@ class SlideMatchingProcessor:
         confidence_weight: float = 2.25,
         use_context_similarity: bool = True,
         context_weight: float = 0.05,
-        context_update_rate: float = 0.25
+        context_update_rate: float = 0.25,
+        min_sentence_length: int = 0
     ):
         """
         Initialize slide matching processor.
@@ -66,6 +67,7 @@ class SlideMatchingProcessor:
             use_context_similarity: Enable context-aware scoring via EMA
             context_weight: Weight for context similarity contribution
             context_update_rate: Update rate for EMA
+            min_sentence_length: Minimum sentence length (words) to use similarity score
         """
         self.model_name = model_name
         self.device = device
@@ -82,6 +84,7 @@ class SlideMatchingProcessor:
         self.use_context_similarity = use_context_similarity
         self.context_weight = context_weight
         self.context_update_rate = context_update_rate
+        self.min_sentence_length = min_sentence_length
         self.model = None
 
         print(f"Initializing Slide Matching Processor")
@@ -272,11 +275,19 @@ class SlideMatchingProcessor:
         backtrack = torch.zeros((num_queries, num_pages), device = self.device, dtype = torch.long)
 
         # Initialize first query
-        dp[0, :] = scores[0, :]
+        # Check if first sentence meets minimum length (count words)
+        first_word_count = len(queries[0].split())
+        first_sentence_long_enough = first_word_count >= self.min_sentence_length
+
+        if first_sentence_long_enough:
+            dp[0, :] = scores[0, :]
+        else:
+            # For short sentences, assign zero score (only jump penalty will apply)
+            dp[0, :] = 0.0
 
         # Initialize context scores (EMA of similarity scores per slide)
         context_scores = torch.zeros(num_pages, device = self.device, dtype = torch.float32)
-        if self.use_context_similarity:
+        if self.use_context_similarity and first_sentence_long_enough:
             context_scores = self.context_update_rate * (scores[0, :] - context_scores)
 
         # Precompute jump penalty matrix (num_pages x num_pages)
@@ -296,11 +307,19 @@ class SlideMatchingProcessor:
 
         # Fill DP table
         for i in range(1, num_queries):
-            current_score = scores[i, :].unsqueeze(0) # [1, num_pages]
+            # Check if current sentence meets minimum length (count words)
+            word_count = len(queries[i].split())
+            sentence_long_enough = word_count >= self.min_sentence_length
 
-            if self.use_context_similarity:
-                current_score += self.context_weight * context_scores.unsqueeze(0)
-            
+            if sentence_long_enough:
+                current_score = scores[i, :].unsqueeze(0) # [1, num_pages]
+
+                if self.use_context_similarity:
+                    current_score += self.context_weight * context_scores.unsqueeze(0)
+            else:
+                # For short sentences, use zero score (only jump penalty applies)
+                current_score = torch.zeros(1, num_pages, device = self.device, dtype = torch.float32)
+
             # Vectorized DP transition
             prev_dp = dp[i - 1, :].unsqueeze(1) # [num_pages, 1]
             current_score_grid = current_score.expand(num_pages, num_pages) # [num_pages, num_pages]
@@ -311,8 +330,8 @@ class SlideMatchingProcessor:
             # Find best previous page k for each current page j
             dp[i, :], backtrack[i, :] = torch.max(scores_with_penalty, dim = 0)
 
-            # Update context scores
-            if self.use_context_similarity:
+            # Update context scores (skip if sentence is too short)
+            if self.use_context_similarity and sentence_long_enough:
                 context_scores += self.context_update_rate * (scores[i, :] - context_scores)
 
         # Backtrack to find optimal path
@@ -419,7 +438,8 @@ if __name__ == "__main__":
         confidence_weight = 2.25,
         use_context_similarity = True,
         context_weight = 0.05,
-        context_update_rate = 0.25
+        context_update_rate = 0.25,
+        min_sentence_length = 3
     )
 
     # Example: match a transcript to slides

--- a/backend/main.py
+++ b/backend/main.py
@@ -236,6 +236,7 @@ def create_pipeline() -> LecturePipeline:
         use_context_similarity = True,
         context_weight = 0.047,
         context_update_rate = 0.24,
+        min_sentence_length = 2,
 
         # Translation settings
         translation_model = "tencent/Hunyuan-MT-7B-fp8",

--- a/backend/main.py
+++ b/backend/main.py
@@ -227,14 +227,14 @@ def create_pipeline() -> LecturePipeline:
 
         # Matching settings
         jump_penalty = 1.5,
-        backward_weight = 2.0,
+        backward_weight = 1.85,
         use_exponential_scaling = True,
-        exponential_scale = 2.79,
+        exponential_scale = 2.785,
         use_confidence_boost = True,
-        confidence_threshold = 0.9,
-        confidence_weight = 2.13,
+        confidence_threshold = 0.913,
+        confidence_weight = 2.18,
         use_context_similarity = True,
-        context_weight = 0.047,
+        context_weight = 0.04,
         context_update_rate = 0.24,
         min_sentence_length = 2,
 


### PR DESCRIPTION
# Slide Matching Algorithm Improvements

## 📝 Description

This PR introduces significant improvements to the slide matching algorithm through the addition of a minimum sentence length filter and optimized hyperparameters.

**Problem**: Short sentences (e.g., "Yes", "Okay", "Um") were being matched to slides based on semantic similarity, often causing incorrect slide transitions and disrupting the overall accuracy of the slide-sentence alignment.

**Solution**:
1. Added a `min_sentence_length` parameter that filters out short sentences from similarity-based matching, allowing them to inherit the previous sentence's slide assignment through the DP algorithm
2. Conducted hyperparameter search to optimize matching parameters for better overall performance

This improvement ensures that only substantive sentences drive slide transitions, while short utterances naturally follow the context of preceding sentences.

---

## 🔨 Changes Made

### 1. Minimum Sentence Length Feature
- **[slide_matching_processor.py](backend/inference_models/slide_matching_processor.py)**: Added `min_sentence_length` parameter
  - Counts words in each sentence during DP matching
  - Short sentences (< threshold) receive zero similarity score, relying only on jump penalty
  - Context scores skip updates for short sentences to maintain semantic coherence
- **[lecture_pipeline.py](backend/inference_models/lecture_pipeline.py)**: Propagated `min_sentence_length` parameter through pipeline initialization
- **[main.py](backend/main.py)**: Configured production value `min_sentence_length = 2` based on testing

### 2. Hyperparameter Optimization
Updated production parameters in [main.py](backend/main.py) based on hyperparameter search results:
- `backward_weight`: 2.0 → 1.85 (reduced penalty for backward jumps)
- `exponential_scale`: 2.79 → 2.785 (fine-tuned confidence scaling)
- `confidence_threshold`: 0.9 → 0.913 (stricter threshold for high-confidence matches)
- `confidence_weight`: 2.13 → 2.18 (increased weight for confident predictions)
- `context_weight`: 0.047 → 0.04 (slightly reduced context influence)

### 3. Technical Implementation Details
- Word counting via `len(sentence.split())` for efficient length checks
- Zero-score assignment for short sentences ensures DP algorithm handles transitions naturally
- Context score EMA updates skip short sentences to preserve semantic context
- Backward compatibility: `min_sentence_length = 0` maintains existing behavior

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally (tested with `test.py`, `test_korean.py`, `test_male_voice.py`)
- [x] Added/updated tests (N/A - algorithm improvement, existing test files validate)
- [x] Updated relevant documentation (parameters documented in docstrings)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)

### Example Scenario
**Before**: Short sentences like "Um", "Yeah", "Okay" would match to random slides based on spurious semantic similarity.

**After**: Short sentences inherit the slide number from the previous substantive sentence, maintaining context and reducing incorrect transitions.

**Configuration**:
```python
min_sentence_length = 2  # Sentences with < 2 words use zero similarity score
```

---

## 🔗 Related Issues / PRs

This PR builds upon the slide matching feature and addresses accuracy issues observed during testing and production use.

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @soarhigh03 
- @del2090 

---

## 📌 Notes for Reviewers

