### PR TITLE
Enforce pdf ratio to 'height / width' in player screen

### DIFF
--- a/frontend/lib/features/player/player_controller.dart
+++ b/frontend/lib/features/player/player_controller.dart
@@ -203,7 +203,9 @@ class PlayerController extends ChangeNotifier {
 
     if (cachedThumbnail != null) {
       _pdfCacheService.setCachedImage(1, cachedThumbnail.image.bytes);
-      pdfAspectRatio = cachedThumbnail.aspectRatio;
+      pdfAspectRatio = cachedThumbnail.aspectRatio < 1
+          ? 1 / cachedThumbnail.aspectRatio
+          : cachedThumbnail.aspectRatio;
       debugPrint(
         '✅ First page pre-loaded from thumbnail cache for $lectureId (aspect ratio: $pdfAspectRatio)',
       );


### PR DESCRIPTION
## 📝 Description
<!-- Provide a concise description of your changes. Why is this change needed? -->

---

This PR is to solve error applied wrong ratio in player.

## 🔨 Changes Made
<!-- List out the main changes (code, docs, configs, etc.) -->
- Enforce pdf ratio to 'height / width' in player screen

---

## ✅ Checklist
- [x] Code compiles without errors
- [x] All tests passed locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation (README, Wiki, etc.)
- [x] Followed coding style and conventions

---

## 📷 Screenshots / Demos (if relevant)
<!-- Add UI screenshots, API responses, or logs to help reviewers understand changes -->

---

## 🔗 Related Issues / PRs
<!-- Link to GitHub issues/PRs this relates to -->
Fixes #

---

## 👥 Reviewers
<!-- Please assign 2 reviewers for this PR -->
- @del2090 
- @

---

## 📌 Notes for Reviewers
<!-- Any special instructions, caveats, or areas that need extra attention -->
